### PR TITLE
Adjust character name validation

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -407,7 +407,15 @@ namespace Content.Shared.Preferences
             var configManager = IoCManager.Resolve<IConfigurationManager>();
             if (configManager.GetCVar(CCVars.RestrictedNames))
             {
-                name = Regex.Replace(name, @"[^A-Z,a-z,0-9, -]", string.Empty);
+                name = Regex.Replace(name, @"[^\u0041-\u005A,\u0061-\u007A,\u00C0-\u00D6,\u00D8-\u00F6,\u00F8-\u00FF,\u0100-\u017F, -]", string.Empty);
+                /*
+                 * 0041-005A  Basic Latin: Uppercase Latin Alphabet
+                 * 0061-007A  Basic Latin: Lowercase Latin Alphabet
+                 * 00C0-00D6  Latin-1 Supplement: Letters I
+                 * 00D8-00F6  Latin-1 Supplement: Letters II
+                 * 00F8-00FF  Latin-1 Supplement: Letters III
+                 * 0100-017F  Latin Extended A: European Latin
+                 */
             }
 
             if (configManager.GetCVar(CCVars.ICNameCase))


### PR DESCRIPTION
## About the PR
The _intended_ goal of `ic.restricted_names` seems to be to ensure that names are intelligible to speakers of the server's primary language, in this case English where legible names are _Romanized_, not _Anglicized_. That is, so long as they are derived from the Latin alphabet, they are readable, although pronunciation is culturally-informed and can only ever be _approximated_ in text.

The previous selection culls a vast domain of names that would otherwise qualify. These are not LRP names or names in languages that English-speakers cannot read; they're names of people who exist in the real world and are an active part of the English-speaking community. We should not exclude realistic names, or force players to choose between cultural authenticity and creative freedom. Also, the previous selection permitted numeric digits, for which there is no conceivable use in MRP.

The Head of Personnel is already able to change a character's name to include these characters; but requiring that be done every round is an undue burden that does not fall on everyone equally, discouraging players from bothering at all. It also results in things like "Ipek Dvorak (as İpek Dvořák)", and does not change the identity used when speaking. Simply put, it's an inadequate solution when we can instead have a less restrictive character name field in the first place.

### Media
![Untitled](https://github.com/DeltaV-Station/Delta-v/assets/20689511/7272884b-7b88-486e-9318-e58b9faf5354)

### Changelog
:cl: Fireheart
- tweak: Adjusted character name validation