### PR TITLE
Small Morphotype Buffs

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -41,8 +41,8 @@
     templateId: diona
   - type: InventorySlots
   - type: MovementSpeedModifier
-    baseWalkSpeed : 1.5
-    baseSprintSpeed : 3.5
+    baseWalkSpeed : 3
+    baseSprintSpeed : 5
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -33,10 +33,11 @@
     soundHit:
       path: /Audio/Weapons/pierce.ogg
     angle: 30
-    animation: WeaponArcPunch
+    animation: WeaponArcClaw
     damage:
       types:
-        Piercing: 5
+        Blunt: 1
+        Slash: 5
   - type: Temperature
     heatDamageThreshold: 400
     coldDamageThreshold: 285
@@ -49,8 +50,8 @@
       types:
         Heat : 0.1 #per second, scales with temperature & other constants
   - type: MovementSpeedModifier
-    baseWalkSpeed : 2.7
-    baseSprintSpeed : 4.5
+    baseWalkSpeed : 3
+    baseSprintSpeed : 5
   - type: Perishable
   - type: Carriable
 

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -20,15 +20,21 @@
     soundHit:
       path: /Audio/Weapons/pierce.ogg
     angle: 30
-    animation: WeaponArcPunch
+    animation: WeaponArcClaw
     damage:
       types:
-        Piercing: 5
+        Blunt: 1
+        Slash: 5
   - type: MovementSpeedModifier
     baseWalkSpeed : 3
     baseSprintSpeed : 5
   - type: Perishable
   - type: Carriable
+  - type: TemperatureProtection
+    coefficient: 0.1
+  - type: Thieving
+    stealthy: true
+    stripTimeReduction: 1
 
 - type: entity
   save: false


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## Buffs to Diona, Lizards, and Vulpkanin


**Changelog**
Diona movement speed changed from
    baseWalkSpeed : 1.5 -> 3 (normal)
    baseSprintSpeed : 3.5 -> 5 (normal)
Lizard movement speed changed
    baseWalkSpeed : 2.7 -> 3 (normal)
    baseSprintSpeed : 4.5 -> 5 (normal)
    
Lizard unarmed attack damage changed
5 Piercing -> 1 Blunt 5 Slash (same as Felinid)
Vulp unarmed attack damaged changed
5 Piercing -> 1 Blunt 5 Slash (same as Felinid)
Lizard and Vulp unarmed attack now uses the slash/claw animation.

Vulp gain thieving component (same as Felinid)
Vulp gain temperature protection (they can walk around on Glacier freely!)


:cl: ODJ
- tweak: Diona, Reptilian, and Vulpkanin morphotypes should feel a bit better.
