### PR TITLE
Fix discord changelogs yet again

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,3 +66,4 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         DISCORD_WEBHOOK_URL: ${{ secrets.CHANGELOG_DISCORD_WEBHOOK }}
+      continue-on-error: true

--- a/Tools/actions_changelogs_since_last_run.py
+++ b/Tools/actions_changelogs_since_last_run.py
@@ -98,9 +98,9 @@ def get_last_changelog(sess: requests.Session, sha: str) -> str:
 
     resp = sess.get(f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_FILE}", headers=headers, params=params)
     resp.raise_for_status()
+    master = yaml.safe_load(resp.text)
     resp2 = sess.get(f"{GITHUB_API_URL}/repos/{GITHUB_REPOSITORY}/contents/{CHANGELOG_FILE_UPSTREAM}", headers=headers, params=params)
     resp2.raise_for_status()
-    master = yaml.safe_load(resp.text)
     upstream = yaml.safe_load(resp2.text)
 
     merged = merge_changelog(master,upstream)


### PR DESCRIPTION
## About the PR
This hopefully finally fixes that script. It will still fail the first time, but it wont cause the whole workflow to be marked as failed. That should mean the first time it runs after that it'll properly read the changelogs. If it doesn't work after this I'm not even gonna bother.