### PR TITLE
Add Salvage Expeditions research to R&D console

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/research/technologies.ftl
@@ -34,6 +34,9 @@ technologies-advanced-life-support-description = The cutting edge of life and de
 technologies-salvage-equipment = Salvage equipment
 technologies-salvage-equipment-description = Newer and faster resource collection.
 
+technologies-salvage-expeditions = Salvage expeditions
+technologies-salvage-expeditions-description = High risk, high reward!
+
 technologies-spacefaring = Spacefaring technology
 technologies-spacefaring-description = Able to bring you into the stars!
 

--- a/Resources/Prototypes/Catalog/Research/technologies.yml
+++ b/Resources/Prototypes/Catalog/Research/technologies.yml
@@ -367,6 +367,21 @@
   - RipleyLLeg
   - RipleyRLeg
 
+- type: technology
+  name: technologies-salvage-expeditions
+  id: SalvageExpeditions
+  description: technologies-salvage-expeditions-description
+  icon:
+    sprite: Structures/Shuttles/thruster.rsi
+    state: base
+  requiredPoints: 30000
+  requiredTechnologies:
+  - SalvageEquipment
+  - ElectricalEngineering
+  - ArchaeologicalEquipment
+  unlockedRecipes:
+  - SalvageExpeditionsComputerCircuitboard
+
 # Industrial Engineering Technology Tree
 
 - type: technology

--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -298,6 +298,7 @@
       - SeedExtractorMachineCircuitboard
       - AnalysisComputerCircuitboard
       - ExosuitFabricatorMachineCircuitboard
+      - SalvageExpeditionsComputerCircuitboard
       - AnomalyVesselCircuitboard
       - APECircuitboard
       - ArtifactAnalyzerMachineCircuitboard

--- a/Resources/Prototypes/Recipes/Lathes/electronics.yml
+++ b/Resources/Prototypes/Recipes/Lathes/electronics.yml
@@ -165,6 +165,14 @@
      Glass: 900
 
 - type: latheRecipe
+  id: SalvageExpeditionsComputerCircuitboard
+  result: SalvageExpeditionsComputerCircuitboard
+  completetime: 5
+  materials:
+     Steel: 100
+     Glass: 900
+
+- type: latheRecipe
   id: UniformPrinterMachineCircuitboard
   result: UniformPrinterMachineCircuitboard
   completetime: 4


### PR DESCRIPTION
## About the PR
This is a reflection back down from [Nyanotrasen #1576](https://www.github.com/Nyanotrasen/Nyanotrasen/pull/1576) in the event that our plans with Expeditions differs from theirs.

This proposal is a compromise between a desire to keep the Expeditions feature from making Salvage an even more absent division than it already is and enabling players to work together to gain access to a fun feature of the game towards end-of-round.

Instead of simply mapping Expedition consoles, this PR would have them locked behind collaboration with Epistemics. Salvagers will also have to work hard to fund Cargo in order to purchase a shuttle with which to go on these expeditions. In short, a large fraction of the crew will be involved in the preparation for an Expedition, and be enriched themselves in the process (Cargo will have $$$, Epi will have some essential midgame research and favors earned from Engineering to get their devices upgraded).

**Media**
![image](https://github.com/Nyanotrasen/Nyanotrasen/assets/20689511/d5b37d1a-0c9b-4fa4-a17d-a3a6d2c79e7c)

**Changelog**
:cl: Fireheart
- add: Add Salvage Expeditions research to R&D console

