### PR TITLE
Update brief permissions from debug to spawn

### DIFF
--- a/Content.Server/Nyanotrasen/Administration/Commands/BriefCommand.cs
+++ b/Content.Server/Nyanotrasen/Administration/Commands/BriefCommand.cs
@@ -9,7 +9,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands.Brief
 {
-    [AdminCommand(AdminFlags.Debug)]
+    [AdminCommand(AdminFlags.Spawn)]
     public sealed class BriefCommand : IConsoleCommand
     {
         [Dependency] private readonly IEntityManager _entities = default!;


### PR DESCRIPTION
Since not having the debug permission removed some important stuff, but brief still should be restricted for those without spawning abilities 