### PR TITLE
Loadcharacter

### DIFF
--- a/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
+++ b/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
@@ -1,0 +1,150 @@
+using System.Linq;
+using Content.Server.DetailExaminable;
+using Content.Shared.CCVar;
+using Content.Server.Players;
+using Content.Server.Humanoid;
+using Content.Shared.Administration;
+using Content.Server.IdentityManagement;
+using Content.Shared.Humanoid;
+using Content.Shared.Preferences;
+using Content.Server.Preferences.Managers;
+using Content.Shared.Humanoid.Prototypes;
+using Robust.Server.Player;
+using Robust.Shared.Console;
+using Robust.Shared.Configuration;
+using Robust.Shared.Prototypes;
+
+namespace Content.Server.Administration.Commands.loadcharacter
+{
+    [AdminCommand(AdminFlags.Debug)]
+    public sealed class loadcharacter : IConsoleCommand
+    {
+        [Dependency] private readonly IEntitySystemManager _entitysys = default!;
+        [Dependency] private readonly IEntityManager _entityManager = default!;
+        [Dependency] private readonly IPrototypeManager _prototypeManager = default!;
+        [Dependency] private readonly IServerPreferencesManager _prefs = default!;
+        [Dependency] private readonly IConfigurationManager _configurationManager = default!;
+
+        public string Command => "loadcharacter";
+        public string Description => "Applies your currently selected character to an entity";
+        public string Help => $"Usage: {Command} | {Command} <entityUid> | {Command} <entityUid> <characterName>";
+
+        public void Execute(IConsoleShell shell, string argStr, string[] args)
+        {
+            var player = shell.Player as IPlayerSession;
+            if (player == null)
+            {
+                shell.WriteError("You aren't a player.");
+                return;
+            }
+
+            var mind = player.ContentData()?.Mind;
+
+            if (mind == null || mind.UserId == null)
+            {
+                shell.WriteError("You don't have a mind.");
+                return;
+            }
+
+            EntityUid target;
+
+            if (args.Length >= 1)
+            {
+                if (!int.TryParse(args.First(), out var entityUid))
+                {
+                    shell.WriteLine(Loc.GetString("shell-entity-uid-must-be-number"));
+                    return;
+                }
+                target = new EntityUid(entityUid);
+            }
+            else
+            {
+                if (player.AttachedEntity == null ||
+                    !_entityManager.HasComponent<HumanoidAppearanceComponent>(player.AttachedEntity.Value))
+                {
+                    shell.WriteError(Loc.GetString("shell-target-entity-does-not-have-message",
+                        ("missing", "AttachedEntity")));
+                    return;
+                }
+                target = player.AttachedEntity.Value;
+            }
+
+            if (!target.IsValid() || !_entityManager.EntityExists(target))
+            {
+                shell.WriteLine(Loc.GetString("shell-invalid-entity-id"));
+                return;
+            }
+
+            if (target == null ||
+                !_entityManager.TryGetComponent<HumanoidAppearanceComponent>(target, out var humanoidAppearance))
+            {
+                shell.WriteError(Loc.GetString("shell-entity-with-uid-lacks-component", ("uid", target), ("componentName", nameof(HumanoidAppearanceComponent))));
+                return;
+            }
+
+            HumanoidCharacterProfile character = new();
+
+            if (args.Length >= 2)
+            {
+                // This seems like a bad way to go about it, but it works so eh?
+                var name = String.Join(" ", args.Skip(1).ToArray());
+                shell.WriteLine($"Attempting to fetch character '{name}'");
+
+                var charIndex = _prefs.GetPreferences(mind.UserId.Value).IndexOfCharacterName(name);
+                if (charIndex < 0)
+                {
+                    shell.WriteError("Fetching failed!");
+                    return;
+                }
+
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).GetProfile(charIndex);
+            }
+            else
+                character = (HumanoidCharacterProfile) _prefs.GetPreferences(mind.UserId.Value).SelectedCharacter;
+
+            // This shouldn't ever fail considering the previous checks
+            if (!_prototypeManager.TryIndex<SpeciesPrototype>(humanoidAppearance.Species, out var speciesPrototype) || !_prototypeManager.TryIndex<SpeciesPrototype>(character.Species, out var entPrototype))
+                return;
+
+            if (speciesPrototype != entPrototype)
+                shell.WriteLine("Species mismatch detected between character and selected entity, this may have unexpected results.");
+
+            _entityManager.System<HumanoidAppearanceSystem>().LoadProfile(target, character);
+
+            if (_entityManager.TryGetComponent<MetaDataComponent>(target, out var metadata))
+                metadata.EntityName = character.Name;
+
+            if (character.FlavorText != "" && _configurationManager.GetCVar(CCVars.FlavorText))
+            {
+                _entityManager.EnsureComponent<DetailExaminableComponent>(target).Content = character.FlavorText;
+            }
+            else
+                _entityManager.RemoveComponent<DetailExaminableComponent>(target);
+
+            _entityManager.System<IdentitySystem>().QueueIdentityUpdate(target);
+            shell.WriteLine("Character load complete");
+        }
+
+        public CompletionResult GetCompletion(IConsoleShell shell, string[] args)
+        {
+            if (args.Length == 2)
+            {
+                var player = shell.Player as IPlayerSession;
+                if (player == null)
+                    return CompletionResult.Empty;
+                var mind = player.ContentData()?.Mind;
+                if (mind == null || mind.UserId == null)
+                    return CompletionResult.Empty;
+                _prefs.TryGetCachedPreferences(mind.UserId.Value, out var pref);
+                if (pref == null)
+                {
+                    return CompletionResult.Empty;
+                }
+
+                return CompletionResult.FromHintOptions(_prefs.GetPreferences(mind.UserId.Value).GetCharacterNames(), "Select Character");
+            }
+
+            return CompletionResult.Empty;
+        }
+    }
+}

--- a/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
+++ b/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
@@ -135,11 +135,6 @@ namespace Content.Server.Administration.Commands.loadcharacter
                 var mind = player.ContentData()?.Mind;
                 if (mind == null || mind.UserId == null)
                     return CompletionResult.Empty;
-                _prefs.TryGetCachedPreferences(mind.UserId.Value, out var pref);
-                if (pref == null)
-                {
-                    return CompletionResult.Empty;
-                }
 
                 return CompletionResult.FromHintOptions(_prefs.GetPreferences(mind.UserId.Value).GetCharacterNames(), "Select Character");
             }

--- a/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
+++ b/Content.Server/DeltaV/Administration/Commands/loadcharacter.cs
@@ -16,7 +16,7 @@ using Robust.Shared.Prototypes;
 
 namespace Content.Server.Administration.Commands.loadcharacter
 {
-    [AdminCommand(AdminFlags.Debug)]
+    [AdminCommand(AdminFlags.Admin)]
     public sealed class loadcharacter : IConsoleCommand
     {
         [Dependency] private readonly IEntitySystemManager _entitysys = default!;

--- a/Content.Shared/Preferences/PlayerPreferences.cs
+++ b/Content.Shared/Preferences/PlayerPreferences.cs
@@ -51,5 +51,19 @@ namespace Content.Shared.Preferences
         {
             return (index = IndexOfCharacter(profile)) != -1;
         }
+
+        public int IndexOfCharacterName(string name)
+        {
+            return _characters.FirstOrNull(p => p.Value.Name == name)?.Key ?? -1;
+        }
+        public List<string> GetCharacterNames()
+        {
+            List<string> charList = new();
+            foreach (var character in _characters)
+            {
+                charList.Add(character.Value.Name);
+            }
+            return charList;
+        }
     }
 }


### PR DESCRIPTION
## About the PR
Adds a command that allows admins to load a character onto a mob, saving a ton of time for setting up events and allowing for this not possible before, such as setting the pronouns and age of a character.

The only downside is attempting to load a character of a diferent species will not apply certain attributes such as size, or additional components. There will be a warning about it, but in some cases it may be intended and it wont cause any major issues.