### PR TITLE
Fix round restart loops

### DIFF
--- a/Content.Server/Traits/TraitSystem.cs
+++ b/Content.Server/Traits/TraitSystem.cs
@@ -40,6 +40,9 @@ public sealed class TraitSystem : EntitySystem
             // Add all components required by the prototype
             foreach (var entry in traitPrototype.Components.Values)
             {
+                if (HasComp(args.Mob, entry.Component.GetType()))
+                    continue;
+
                 var comp = (Component) _serializationManager.CreateCopy(entry.Component, notNullableOverride: true);
                 comp.Owner = args.Mob;
                 EntityManager.AddComponent(args.Mob, comp);

--- a/Resources/Changelog/DeltaVChangelog.yml
+++ b/Resources/Changelog/DeltaVChangelog.yml
@@ -55,3 +55,9 @@ Entries:
         type: Tweak
     id: 9
     time: '2023-05-16T08:00:00.0000000+00:00'
+  - author: Debug
+    changes:
+      - message: Mimes with the muted trait should no longer cause round restart loops, if only they spoke up about it sooner.
+        type: Fix
+    id: 10
+    time: '2023-05-18T00:00:00.0000000+00:00'


### PR DESCRIPTION
Imagine having your space game crash because some mimes decided they wanted to be extra muted. Anyways, this should prevent something like this from happening again.