### PR TITLE
Remove fixtures from CentComm

### DIFF
--- a/Resources/Maps/centcomm.yml
+++ b/Resources/Maps/centcomm.yml
@@ -122,8 +122,6 @@ entities:
       fixedRotation: False
       bodyType: Dynamic
       type: Physics
-    - fixtures: {}
-      type: Fixtures
     - id: centcomm
       type: BecomesStation
     - gravityShakeSound: !type:SoundPathSpecifier
@@ -4687,120 +4685,86 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 858
     components:
     - pos: 20.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 859
     components:
     - pos: 20.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 860
     components:
     - pos: 20.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 861
     components:
     - pos: 20.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 862
     components:
     - pos: 21.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 863
     components:
     - pos: 22.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 864
     components:
     - pos: 23.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 865
     components:
     - pos: 24.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 866
     components:
     - pos: 25.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 867
     components:
     - pos: 26.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 868
     components:
     - pos: 27.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 869
     components:
     - pos: 28.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 870
     components:
     - pos: 29.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 871
     components:
     - pos: 30.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 872
     components:
     - pos: 31.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 873
     components:
     - pos: 32.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 874
     components:
     - pos: 33.5,2.5
@@ -4808,8 +4772,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 875
     components:
     - pos: 34.5,2.5
@@ -4817,92 +4779,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 876
     components:
     - pos: 21.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 877
     components:
     - pos: 22.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 878
     components:
     - pos: 23.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 879
     components:
     - pos: 24.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 880
     components:
     - pos: 25.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 881
     components:
     - pos: 26.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 882
     components:
     - pos: 27.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 883
     components:
     - pos: 28.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 884
     components:
     - pos: 29.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 885
     components:
     - pos: 30.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 886
     components:
     - pos: 31.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 887
     components:
     - pos: 32.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 888
     components:
     - pos: 33.5,4.5
@@ -4910,15 +4846,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 889
     components:
     - pos: 26.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 890
     components:
     - pos: 30.5,6.5
@@ -4926,8 +4858,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 891
     components:
     - pos: 28.5,6.5
@@ -4935,15 +4865,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 892
     components:
     - pos: 20.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 893
     components:
     - pos: 24.5,7.5
@@ -4951,36 +4877,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 894
     components:
     - pos: 20.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 895
     components:
     - pos: 20.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 896
     components:
     - pos: 32.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 897
     components:
     - pos: 32.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 899
     components:
     - pos: 29.5,6.5
@@ -4988,8 +4904,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 900
     components:
     - pos: 28.5,7.5
@@ -4997,15 +4911,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 901
     components:
     - pos: 31.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 902
     components:
     - pos: 24.5,6.5
@@ -5013,8 +4923,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 903
     components:
     - pos: 23.5,6.5
@@ -5022,8 +4930,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 904
     components:
     - pos: 22.5,6.5
@@ -5031,8 +4937,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 906
     components:
     - pos: 20.5,-7.5
@@ -5040,120 +4944,86 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 907
     components:
     - pos: 20.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 908
     components:
     - pos: 20.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 909
     components:
     - pos: 20.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 910
     components:
     - pos: 20.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 911
     components:
     - pos: 21.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 912
     components:
     - pos: 22.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 913
     components:
     - pos: 23.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 914
     components:
     - pos: 24.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 915
     components:
     - pos: 25.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 916
     components:
     - pos: 26.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 917
     components:
     - pos: 27.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 918
     components:
     - pos: 28.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 919
     components:
     - pos: 29.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 920
     components:
     - pos: 30.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 921
     components:
     - pos: 31.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 922
     components:
     - pos: 32.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 923
     components:
     - pos: 33.5,-3.5
@@ -5161,8 +5031,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 924
     components:
     - pos: 34.5,-3.5
@@ -5170,92 +5038,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 925
     components:
     - pos: 21.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 926
     components:
     - pos: 22.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 927
     components:
     - pos: 23.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 928
     components:
     - pos: 24.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 929
     components:
     - pos: 25.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 930
     components:
     - pos: 26.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 931
     components:
     - pos: 27.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 932
     components:
     - pos: 28.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 933
     components:
     - pos: 29.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 934
     components:
     - pos: 30.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 935
     components:
     - pos: 31.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 936
     components:
     - pos: 32.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 937
     components:
     - pos: 33.5,-5.5
@@ -5263,15 +5105,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 938
     components:
     - pos: 31.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 939
     components:
     - pos: 31.5,-7.5
@@ -5279,8 +5117,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 940
     components:
     - pos: 21.5,-7.5
@@ -5288,8 +5124,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 941
     components:
     - pos: 21.5,6.5
@@ -5297,8 +5131,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 942
     components:
     - pos: 31.5,6.5
@@ -5306,8 +5138,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 943
     components:
     - pos: 33.5,3.5
@@ -5315,8 +5145,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 944
     components:
     - pos: 33.5,5.5
@@ -5324,8 +5152,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 945
     components:
     - pos: 33.5,1.5
@@ -5333,8 +5159,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 946
     components:
     - pos: 35.5,2.5
@@ -5342,8 +5166,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 947
     components:
     - pos: 35.5,1.5
@@ -5351,8 +5173,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 948
     components:
     - pos: 35.5,3.5
@@ -5360,8 +5180,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 949
     components:
     - pos: 35.5,4.5
@@ -5369,8 +5187,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 950
     components:
     - pos: 35.5,5.5
@@ -5378,8 +5194,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 951
     components:
     - pos: 35.5,-3.5
@@ -5387,8 +5201,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 952
     components:
     - pos: 35.5,-2.5
@@ -5396,8 +5208,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 953
     components:
     - pos: 35.5,-4.5
@@ -5405,8 +5215,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 954
     components:
     - pos: 35.5,-5.5
@@ -5414,8 +5222,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 955
     components:
     - pos: 35.5,-6.5
@@ -5423,8 +5229,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 956
     components:
     - pos: 33.5,-6.5
@@ -5432,8 +5236,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 957
     components:
     - pos: 33.5,-4.5
@@ -5441,8 +5243,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 958
     components:
     - pos: 33.5,-2.5
@@ -5450,8 +5250,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 959
     components:
     - pos: 34.5,-2.5
@@ -5459,8 +5257,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 960
     components:
     - pos: 34.5,-1.5
@@ -5468,8 +5264,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 961
     components:
     - pos: 34.5,0.5
@@ -5477,8 +5271,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 962
     components:
     - pos: 34.5,1.5
@@ -5486,8 +5278,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 964
     components:
     - pos: 23.5,-10.5
@@ -5495,85 +5285,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 965
     components:
     - pos: 24.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 966
     components:
     - pos: 25.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 967
     components:
     - pos: 26.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 968
     components:
     - pos: 26.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 969
     components:
     - pos: 26.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 970
     components:
     - pos: 26.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 971
     components:
     - pos: 22.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 972
     components:
     - pos: 22.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 973
     components:
     - pos: 21.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 975
     components:
     - pos: 20.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 976
     components:
     - pos: 32.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 980
     components:
     - pos: 9.5,2.5
@@ -5581,99 +5347,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 981
     components:
     - pos: 9.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 982
     components:
     - pos: 9.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 983
     components:
     - pos: 9.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 984
     components:
     - pos: 9.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 985
     components:
     - pos: 9.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 986
     components:
     - pos: 10.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 987
     components:
     - pos: 11.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 988
     components:
     - pos: 12.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 989
     components:
     - pos: 13.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 990
     components:
     - pos: 14.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 991
     components:
     - pos: 15.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 992
     components:
     - pos: 15.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 993
     components:
     - pos: 16.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 994
     components:
     - pos: 16.5,-0.5
@@ -5681,15 +5419,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 995
     components:
     - pos: 17.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 996
     components:
     - pos: 18.5,-0.5
@@ -5697,8 +5431,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 997
     components:
     - pos: 8.5,-0.5
@@ -5706,15 +5438,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 998
     components:
     - pos: 5.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 999
     components:
     - pos: 6.5,-0.5
@@ -5722,8 +5450,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1000
     components:
     - pos: 10.5,-3.5
@@ -5731,85 +5457,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1001
     components:
     - pos: 10.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1002
     components:
     - pos: 10.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1003
     components:
     - pos: 10.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1004
     components:
     - pos: 10.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1005
     components:
     - pos: 11.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1006
     components:
     - pos: 12.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1007
     components:
     - pos: 13.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1008
     components:
     - pos: 14.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1009
     components:
     - pos: 15.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1010
     components:
     - pos: 16.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1011
     components:
     - pos: 17.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1012
     components:
     - pos: 17.5,-5.5
@@ -5817,22 +5519,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1013
     components:
     - pos: 13.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1014
     components:
     - pos: 13.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1015
     components:
     - pos: 13.5,-3.5
@@ -5840,15 +5536,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1016
     components:
     - pos: 12.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1017
     components:
     - pos: 11.5,-3.5
@@ -5856,15 +5548,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1018
     components:
     - pos: 14.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1019
     components:
     - pos: 15.5,-3.5
@@ -5872,8 +5560,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1020
     components:
     - pos: 12.5,7.5
@@ -5881,36 +5567,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1021
     components:
     - pos: 12.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1022
     components:
     - pos: 12.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1023
     components:
     - pos: 12.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1024
     components:
     - pos: 12.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1025
     components:
     - pos: 12.5,2.5
@@ -5918,8 +5594,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1026
     components:
     - pos: 13.5,2.5
@@ -5927,8 +5601,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1027
     components:
     - pos: 14.5,2.5
@@ -5936,8 +5608,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1028
     components:
     - pos: 15.5,2.5
@@ -5945,8 +5615,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1029
     components:
     - pos: 11.5,2.5
@@ -5954,43 +5622,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1030
     components:
     - pos: 13.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1031
     components:
     - pos: 14.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1032
     components:
     - pos: 15.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1033
     components:
     - pos: 16.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1034
     components:
     - pos: 17.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1035
     components:
     - pos: 17.5,4.5
@@ -5998,8 +5654,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1036
     components:
     - pos: 17.5,6.5
@@ -6007,8 +5661,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1037
     components:
     - pos: 13.5,7.5
@@ -6016,8 +5668,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1038
     components:
     - pos: 14.5,7.5
@@ -6025,8 +5675,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1039
     components:
     - pos: 11.5,7.5
@@ -6034,8 +5682,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1040
     components:
     - pos: 10.5,7.5
@@ -6043,8 +5689,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1041
     components:
     - pos: 9.5,7.5
@@ -6052,29 +5696,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1042
     components:
     - pos: 11.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1043
     components:
     - pos: 10.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1044
     components:
     - pos: 9.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1045
     components:
     - pos: 8.5,5.5
@@ -6082,15 +5718,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1046
     components:
     - pos: 9.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1047
     components:
     - pos: 8.5,4.5
@@ -6098,22 +5730,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1048
     components:
     - pos: 8.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1049
     components:
     - pos: 7.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1050
     components:
     - pos: 7.5,4.5
@@ -6121,8 +5747,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1051
     components:
     - pos: 12.5,8.5
@@ -6130,8 +5754,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1052
     components:
     - pos: 12.5,9.5
@@ -6139,8 +5761,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1053
     components:
     - pos: 13.5,9.5
@@ -6148,8 +5768,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1054
     components:
     - pos: 14.5,9.5
@@ -6157,8 +5775,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1055
     components:
     - pos: 11.5,9.5
@@ -6166,8 +5782,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1056
     components:
     - pos: 10.5,9.5
@@ -6175,8 +5789,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1057
     components:
     - pos: 9.5,9.5
@@ -6184,8 +5796,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1058
     components:
     - pos: 8.5,9.5
@@ -6193,8 +5803,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1059
     components:
     - pos: 7.5,9.5
@@ -6202,8 +5810,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1060
     components:
     - pos: 6.5,9.5
@@ -6211,8 +5817,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1061
     components:
     - pos: 8.5,8.5
@@ -6220,50 +5824,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1062
     components:
     - pos: 28.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1063
     components:
     - pos: 28.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1064
     components:
     - pos: 28.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1068
     components:
     - pos: 24.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1069
     components:
     - pos: 24.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1070
     components:
     - pos: 24.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1089
     components:
     - pos: -2.5,2.5
@@ -6271,78 +5861,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1090
     components:
     - pos: -2.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1091
     components:
     - pos: -2.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1092
     components:
     - pos: -2.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1093
     components:
     - pos: -2.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1094
     components:
     - pos: -1.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1095
     components:
     - pos: -0.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1096
     components:
     - pos: 0.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1097
     components:
     - pos: 1.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1098
     components:
     - pos: 2.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1099
     components:
     - pos: 2.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1100
     components:
     - pos: 2.5,2.5
@@ -6350,8 +5918,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1101
     components:
     - pos: 3.5,2.5
@@ -6359,8 +5925,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1102
     components:
     - pos: 3.5,1.5
@@ -6368,15 +5932,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1103
     components:
     - pos: -3.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1104
     components:
     - pos: -4.5,1.5
@@ -6384,8 +5944,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1105
     components:
     - pos: -4.5,2.5
@@ -6393,8 +5951,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1106
     components:
     - pos: -3.5,2.5
@@ -6402,8 +5958,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1107
     components:
     - pos: -1.5,2.5
@@ -6411,8 +5965,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1108
     components:
     - pos: -0.5,2.5
@@ -6420,8 +5972,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1109
     components:
     - pos: 0.5,2.5
@@ -6429,15 +5979,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1110
     components:
     - pos: -3.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1111
     components:
     - pos: -4.5,-0.5
@@ -6445,8 +5991,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1112
     components:
     - pos: -4.5,-1.5
@@ -6454,8 +5998,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1113
     components:
     - pos: -4.5,-2.5
@@ -6463,15 +6005,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1114
     components:
     - pos: -2.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1115
     components:
     - pos: -2.5,-3.5
@@ -6479,8 +6017,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1116
     components:
     - pos: -3.5,-3.5
@@ -6488,29 +6024,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1117
     components:
     - pos: -1.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1118
     components:
     - pos: -0.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1119
     components:
     - pos: -0.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1120
     components:
     - pos: -0.5,-3.5
@@ -6518,29 +6046,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1121
     components:
     - pos: 0.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1122
     components:
     - pos: 1.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1123
     components:
     - pos: 2.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1124
     components:
     - pos: 3.5,-1.5
@@ -6548,8 +6068,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1125
     components:
     - pos: 3.5,-0.5
@@ -6557,8 +6075,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1126
     components:
     - pos: 3.5,-2.5
@@ -6566,15 +6082,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1127
     components:
     - pos: 1.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1128
     components:
     - pos: 1.5,-3.5
@@ -6582,8 +6094,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1129
     components:
     - pos: 2.5,-3.5
@@ -6591,15 +6101,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1137
     components:
     - pos: 21.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1202
     components:
     - pos: 10.5,-8.5
@@ -6607,8 +6113,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1203
     components:
     - pos: 11.5,-8.5
@@ -6616,8 +6120,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1204
     components:
     - pos: 9.5,-8.5
@@ -6625,15 +6127,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1205
     components:
     - pos: 14.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1206
     components:
     - pos: 14.5,-8.5
@@ -6641,8 +6139,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1207
     components:
     - pos: 15.5,-8.5
@@ -6650,8 +6146,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1208
     components:
     - pos: 13.5,-8.5
@@ -6659,8 +6153,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1209
     components:
     - pos: 12.5,-10.5
@@ -6668,8 +6160,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1210
     components:
     - pos: 12.5,-9.5
@@ -6677,8 +6167,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1211
     components:
     - pos: 13.5,-10.5
@@ -6686,8 +6174,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1212
     components:
     - pos: 14.5,-10.5
@@ -6695,8 +6181,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1213
     components:
     - pos: 15.5,-10.5
@@ -6704,8 +6188,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1214
     components:
     - pos: 16.5,-10.5
@@ -6713,8 +6195,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1215
     components:
     - pos: 16.5,-9.5
@@ -6722,8 +6202,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1216
     components:
     - pos: 11.5,-10.5
@@ -6731,8 +6209,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1217
     components:
     - pos: 10.5,-10.5
@@ -6740,8 +6216,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1218
     components:
     - pos: 9.5,-10.5
@@ -6749,57 +6223,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1219
     components:
     - pos: 12.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1220
     components:
     - pos: 12.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1221
     components:
     - pos: 12.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1222
     components:
     - pos: 12.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1223
     components:
     - pos: 12.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1224
     components:
     - pos: 12.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1225
     components:
     - pos: 12.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1226
     components:
     - pos: 11.5,-16.5
@@ -6807,64 +6265,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1227
     components:
     - pos: 11.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1228
     components:
     - pos: 10.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1229
     components:
     - pos: 9.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1230
     components:
     - pos: 13.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1231
     components:
     - pos: 14.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1232
     components:
     - pos: 15.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1233
     components:
     - pos: 11.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1234
     components:
     - pos: 10.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1236
     components:
     - pos: 3.5,-8.5
@@ -6872,71 +6312,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1237
     components:
     - pos: 3.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1238
     components:
     - pos: 4.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1239
     components:
     - pos: 4.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1240
     components:
     - pos: 4.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1241
     components:
     - pos: 4.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1242
     components:
     - pos: 4.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1243
     components:
     - pos: 5.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1244
     components:
     - pos: 6.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1245
     components:
     - pos: 7.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1246
     components:
     - pos: 7.5,-10.5
@@ -6944,15 +6364,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1247
     components:
     - pos: 5.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1248
     components:
     - pos: 6.5,-9.5
@@ -6960,8 +6376,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1249
     components:
     - pos: 7.5,-12.5
@@ -6969,15 +6383,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1250
     components:
     - pos: 5.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1251
     components:
     - pos: 6.5,-13.5
@@ -6985,15 +6395,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1252
     components:
     - pos: 3.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1253
     components:
     - pos: 2.5,-10.5
@@ -7001,15 +6407,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1254
     components:
     - pos: 3.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1255
     components:
     - pos: 2.5,-13.5
@@ -7017,22 +6419,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1256
     components:
     - pos: 4.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1257
     components:
     - pos: 4.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1258
     components:
     - pos: 5.5,-7.5
@@ -7040,8 +6436,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1259
     components:
     - pos: 3.5,-7.5
@@ -7049,8 +6443,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1260
     components:
     - pos: -1.5,-6.5
@@ -7058,29 +6450,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1261
     components:
     - pos: -1.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1262
     components:
     - pos: -0.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1263
     components:
     - pos: 0.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1264
     components:
     - pos: 0.5,-6.5
@@ -7088,22 +6472,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1265
     components:
     - pos: 1.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1266
     components:
     - pos: 2.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1267
     components:
     - pos: 2.5,-6.5
@@ -7111,29 +6489,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1268
     components:
     - pos: 3.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1269
     components:
     - pos: 4.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1270
     components:
     - pos: 5.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1271
     components:
     - pos: 6.5,-5.5
@@ -7141,8 +6511,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1272
     components:
     - pos: 6.5,-4.5
@@ -7150,36 +6518,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1273
     components:
     - pos: 5.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1274
     components:
     - pos: 5.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1275
     components:
     - pos: 5.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1276
     components:
     - pos: 9.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1277
     components:
     - pos: 8.5,-5.5
@@ -7187,8 +6545,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1278
     components:
     - pos: 8.5,-4.5
@@ -7196,232 +6552,166 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1279
     components:
     - pos: 5.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1280
     components:
     - pos: 5.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1281
     components:
     - pos: 5.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1282
     components:
     - pos: 5.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1283
     components:
     - pos: 5.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1284
     components:
     - pos: 5.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1285
     components:
     - pos: 4.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1286
     components:
     - pos: 3.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1287
     components:
     - pos: 2.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1288
     components:
     - pos: 1.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1289
     components:
     - pos: 0.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1290
     components:
     - pos: -0.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1291
     components:
     - pos: -1.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1292
     components:
     - pos: -2.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1293
     components:
     - pos: -3.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1294
     components:
     - pos: -4.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1295
     components:
     - pos: -5.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1296
     components:
     - pos: -6.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1297
     components:
     - pos: -6.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1298
     components:
     - pos: -6.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1299
     components:
     - pos: -6.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1300
     components:
     - pos: -6.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1301
     components:
     - pos: -6.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1302
     components:
     - pos: -6.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1303
     components:
     - pos: -6.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1304
     components:
     - pos: -6.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1305
     components:
     - pos: -6.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1306
     components:
     - pos: -6.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1307
     components:
     - pos: -5.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1308
     components:
     - pos: -4.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1309
     components:
     - pos: -3.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1310
     components:
     - pos: -2.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1311
     components:
     - pos: -3.5,-6.5
@@ -7429,8 +6719,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1312
     components:
     - pos: -7.5,-5.5
@@ -7438,8 +6726,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1313
     components:
     - pos: -7.5,-4.5
@@ -7447,8 +6733,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1314
     components:
     - pos: -7.5,-0.5
@@ -7456,8 +6740,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1315
     components:
     - pos: -7.5,3.5
@@ -7465,8 +6747,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1316
     components:
     - pos: -7.5,4.5
@@ -7474,8 +6754,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1317
     components:
     - pos: -1.5,5.5
@@ -7483,8 +6761,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1318
     components:
     - pos: 0.5,5.5
@@ -7492,8 +6768,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1319
     components:
     - pos: 2.5,5.5
@@ -7501,8 +6775,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1320
     components:
     - pos: 4.5,5.5
@@ -7510,8 +6782,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1342
     components:
     - pos: -3.5,-9.5
@@ -7519,36 +6789,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1343
     components:
     - pos: -2.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1344
     components:
     - pos: -1.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1345
     components:
     - pos: -0.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1346
     components:
     - pos: 0.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1347
     components:
     - pos: 0.5,-8.5
@@ -7556,8 +6816,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1348
     components:
     - pos: -1.5,-8.5
@@ -7565,43 +6823,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1349
     components:
     - pos: -0.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1350
     components:
     - pos: -0.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1351
     components:
     - pos: -0.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1352
     components:
     - pos: -0.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1353
     components:
     - pos: -1.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1354
     components:
     - pos: -1.5,-14.5
@@ -7609,8 +6855,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1355
     components:
     - pos: -2.5,-14.5
@@ -7618,15 +6862,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1356
     components:
     - pos: 0.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1357
     components:
     - pos: 0.5,-14.5
@@ -7634,8 +6874,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1358
     components:
     - pos: 1.5,-14.5
@@ -7643,36 +6881,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1359
     components:
     - pos: -4.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1360
     components:
     - pos: -5.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1361
     components:
     - pos: -5.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1362
     components:
     - pos: -5.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1363
     components:
     - pos: -4.5,-7.5
@@ -7680,8 +6908,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1364
     components:
     - pos: -6.5,-7.5
@@ -7689,43 +6915,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1365
     components:
     - pos: -5.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1366
     components:
     - pos: -5.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1367
     components:
     - pos: -6.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1368
     components:
     - pos: -7.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1369
     components:
     - pos: -8.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1370
     components:
     - pos: -8.5,-10.5
@@ -7733,8 +6947,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1371
     components:
     - pos: -8.5,-12.5
@@ -7742,29 +6954,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1372
     components:
     - pos: -5.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1373
     components:
     - pos: -5.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1374
     components:
     - pos: -4.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1375
     components:
     - pos: -3.5,-10.5
@@ -7772,8 +6976,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1376
     components:
     - pos: -3.5,-13.5
@@ -7781,22 +6983,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1377
     components:
     - pos: -4.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1378
     components:
     - pos: -6.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1379
     components:
     - pos: -7.5,-13.5
@@ -7804,8 +7000,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1380
     components:
     - pos: -7.5,-14.5
@@ -7813,8 +7007,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1381
     components:
     - pos: -8.5,-14.5
@@ -7822,15 +7014,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1382
     components:
     - pos: -6.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1383
     components:
     - pos: -7.5,-9.5
@@ -7838,15 +7026,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1468
     components:
     - pos: 15.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1469
     components:
     - pos: 16.5,-4.5
@@ -7854,22 +7038,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1470
     components:
     - pos: 15.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1471
     components:
     - pos: 15.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1472
     components:
     - pos: 16.5,3.5
@@ -7877,36 +7055,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1678
     components:
     - pos: -6.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1679
     components:
     - pos: -6.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1680
     components:
     - pos: -6.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1681
     components:
     - pos: -5.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1682
     components:
     - pos: -4.5,17.5
@@ -7914,8 +7082,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1683
     components:
     - pos: -8.5,13.5
@@ -7923,64 +7089,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1684
     components:
     - pos: -8.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1685
     components:
     - pos: -8.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1686
     components:
     - pos: -8.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1687
     components:
     - pos: -8.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1688
     components:
     - pos: -7.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1689
     components:
     - pos: -6.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1690
     components:
     - pos: -5.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1691
     components:
     - pos: -5.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1692
     components:
     - pos: -4.5,8.5
@@ -7988,22 +7136,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1693
     components:
     - pos: -5.5,7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1694
     components:
     - pos: -5.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1695
     components:
     - pos: -4.5,6.5
@@ -8011,8 +7153,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1696
     components:
     - pos: -6.5,6.5
@@ -8020,71 +7160,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1697
     components:
     - pos: -9.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1698
     components:
     - pos: -10.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1699
     components:
     - pos: -11.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1700
     components:
     - pos: -9.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1701
     components:
     - pos: -10.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1702
     components:
     - pos: -11.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1703
     components:
     - pos: -7.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1704
     components:
     - pos: -6.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1705
     components:
     - pos: -6.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1706
     components:
     - pos: -14.5,18.5
@@ -8092,22 +7212,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1707
     components:
     - pos: -14.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1708
     components:
     - pos: -15.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1709
     components:
     - pos: -16.5,17.5
@@ -8115,8 +7229,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1710
     components:
     - pos: -16.5,18.5
@@ -8124,8 +7236,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1711
     components:
     - pos: -15.5,18.5
@@ -8133,8 +7243,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1712
     components:
     - pos: -13.5,18.5
@@ -8142,8 +7250,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1713
     components:
     - pos: -12.5,18.5
@@ -8151,78 +7257,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1714
     components:
     - pos: -14.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1715
     components:
     - pos: -14.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1716
     components:
     - pos: -13.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1717
     components:
     - pos: -12.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1718
     components:
     - pos: -11.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1719
     components:
     - pos: -10.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1720
     components:
     - pos: -9.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1721
     components:
     - pos: -10.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1722
     components:
     - pos: -10.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1723
     components:
     - pos: -10.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1724
     components:
     - pos: -4.5,19.5
@@ -8230,148 +7314,106 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1725
     components:
     - pos: -5.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1726
     components:
     - pos: -6.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1727
     components:
     - pos: -7.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1728
     components:
     - pos: -8.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1729
     components:
     - pos: -9.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1730
     components:
     - pos: -10.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1731
     components:
     - pos: -11.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1732
     components:
     - pos: -11.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1733
     components:
     - pos: -11.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1734
     components:
     - pos: -11.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1735
     components:
     - pos: -11.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1736
     components:
     - pos: -11.5,24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1737
     components:
     - pos: -11.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1738
     components:
     - pos: -11.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1739
     components:
     - pos: -11.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1740
     components:
     - pos: -11.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1741
     components:
     - pos: -11.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1742
     components:
     - pos: -11.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1743
     components:
     - pos: -11.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1744
     components:
     - pos: -12.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1745
     components:
     - pos: -12.5,32.5
@@ -8379,43 +7421,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1746
     components:
     - pos: -10.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1747
     components:
     - pos: -9.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1748
     components:
     - pos: -8.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1749
     components:
     - pos: -7.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1750
     components:
     - pos: -6.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1751
     components:
     - pos: -6.5,32.5
@@ -8423,36 +7453,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1752
     components:
     - pos: -9.5,32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1753
     components:
     - pos: -9.5,33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1754
     components:
     - pos: -12.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1755
     components:
     - pos: -13.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1756
     components:
     - pos: -14.5,30.5
@@ -8460,8 +7480,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1757
     components:
     - pos: -14.5,29.5
@@ -8469,8 +7487,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1758
     components:
     - pos: -15.5,29.5
@@ -8478,8 +7494,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1759
     components:
     - pos: -16.5,29.5
@@ -8487,22 +7501,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1760
     components:
     - pos: -12.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1761
     components:
     - pos: -13.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1762
     components:
     - pos: -14.5,26.5
@@ -8510,8 +7518,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1763
     components:
     - pos: -15.5,26.5
@@ -8519,8 +7525,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1764
     components:
     - pos: -16.5,26.5
@@ -8528,22 +7532,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1765
     components:
     - pos: -12.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1766
     components:
     - pos: -13.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1767
     components:
     - pos: -14.5,23.5
@@ -8551,8 +7549,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1768
     components:
     - pos: -15.5,23.5
@@ -8560,8 +7556,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1769
     components:
     - pos: -16.5,23.5
@@ -8569,8 +7563,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1770
     components:
     - pos: -14.5,22.5
@@ -8578,8 +7570,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1771
     components:
     - pos: -14.5,21.5
@@ -8587,8 +7577,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1772
     components:
     - pos: -14.5,20.5
@@ -8596,141 +7584,101 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1773
     components:
     - pos: -10.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1774
     components:
     - pos: -9.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1775
     components:
     - pos: -8.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1776
     components:
     - pos: -7.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1777
     components:
     - pos: -6.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1778
     components:
     - pos: -6.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1779
     components:
     - pos: -6.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1780
     components:
     - pos: -6.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1781
     components:
     - pos: -6.5,24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1782
     components:
     - pos: -6.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1783
     components:
     - pos: -6.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1784
     components:
     - pos: -6.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1785
     components:
     - pos: -6.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1786
     components:
     - pos: -6.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1787
     components:
     - pos: -6.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1788
     components:
     - pos: -7.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1789
     components:
     - pos: -8.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1790
     components:
     - pos: -9.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1791
     components:
     - pos: -10.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1956
     components:
     - pos: 1.5,17.5
@@ -8738,78 +7686,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1957
     components:
     - pos: 1.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1958
     components:
     - pos: 1.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1959
     components:
     - pos: 1.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1960
     components:
     - pos: 1.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1961
     components:
     - pos: 1.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1962
     components:
     - pos: 1.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1963
     components:
     - pos: 1.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1964
     components:
     - pos: 1.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1965
     components:
     - pos: 1.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1966
     components:
     - pos: 2.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1967
     components:
     - pos: 3.5,8.5
@@ -8817,15 +7743,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1968
     components:
     - pos: 2.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1969
     components:
     - pos: 3.5,10.5
@@ -8833,15 +7755,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1970
     components:
     - pos: 2.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1971
     components:
     - pos: 3.5,12.5
@@ -8849,15 +7767,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1972
     components:
     - pos: 2.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1973
     components:
     - pos: 3.5,14.5
@@ -8865,15 +7779,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1974
     components:
     - pos: 2.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1975
     components:
     - pos: 3.5,16.5
@@ -8881,8 +7791,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1976
     components:
     - pos: 2.5,17.5
@@ -8890,8 +7798,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1977
     components:
     - pos: -3.5,17.5
@@ -8899,92 +7805,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1978
     components:
     - pos: 0.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1979
     components:
     - pos: -0.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1980
     components:
     - pos: -1.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1981
     components:
     - pos: -2.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1982
     components:
     - pos: -2.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1983
     components:
     - pos: -2.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1984
     components:
     - pos: -2.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1985
     components:
     - pos: -2.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1986
     components:
     - pos: -2.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1987
     components:
     - pos: -2.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1988
     components:
     - pos: -2.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1989
     components:
     - pos: -1.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1990
     components:
     - pos: -1.5,7.5
@@ -8992,15 +7872,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1991
     components:
     - pos: 0.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1992
     components:
     - pos: 0.5,7.5
@@ -9008,15 +7884,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1993
     components:
     - pos: -0.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2020
     components:
     - pos: -1.5,22.5
@@ -9024,8 +7896,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2021
     components:
     - pos: -1.5,23.5
@@ -9033,8 +7903,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2022
     components:
     - pos: -1.5,24.5
@@ -9042,8 +7910,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2023
     components:
     - pos: -2.5,24.5
@@ -9051,15 +7917,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2024
     components:
     - pos: -1.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2025
     components:
     - pos: -1.5,20.5
@@ -9067,8 +7929,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2026
     components:
     - pos: -0.5,20.5
@@ -9076,8 +7936,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2027
     components:
     - pos: -0.5,19.5
@@ -9085,8 +7943,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2028
     components:
     - pos: -0.5,18.5
@@ -9094,8 +7950,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2029
     components:
     - pos: 0.5,20.5
@@ -9103,8 +7957,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2030
     components:
     - pos: 1.5,20.5
@@ -9112,15 +7964,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2031
     components:
     - pos: -2.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2057
     components:
     - pos: -3.5,5.5
@@ -9128,8 +7976,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2567
     components:
     - pos: 17.5,17.5
@@ -9137,57 +7983,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2568
     components:
     - pos: 17.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2569
     components:
     - pos: 17.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2570
     components:
     - pos: 17.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2571
     components:
     - pos: 17.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2572
     components:
     - pos: 17.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2573
     components:
     - pos: 17.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2574
     components:
     - pos: 16.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2575
     components:
     - pos: 15.5,12.5
@@ -9195,15 +8025,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2576
     components:
     - pos: 16.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2577
     components:
     - pos: 15.5,14.5
@@ -9211,22 +8037,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2578
     components:
     - pos: 17.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2579
     components:
     - pos: 16.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2580
     components:
     - pos: 15.5,10.5
@@ -9234,57 +8054,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2581
     components:
     - pos: 18.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2582
     components:
     - pos: 19.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2583
     components:
     - pos: 20.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2584
     components:
     - pos: 18.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2585
     components:
     - pos: 19.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2586
     components:
     - pos: 20.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2587
     components:
     - pos: 19.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2588
     components:
     - pos: 21.5,20.5
@@ -9292,57 +8096,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2589
     components:
     - pos: 20.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2590
     components:
     - pos: 19.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2591
     components:
     - pos: 18.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2592
     components:
     - pos: 19.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2593
     components:
     - pos: 19.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2594
     components:
     - pos: 19.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2595
     components:
     - pos: 19.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2596
     components:
     - pos: 21.5,21.5
@@ -9350,169 +8138,121 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2597
     components:
     - pos: 22.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2598
     components:
     - pos: 23.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2599
     components:
     - pos: 23.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2600
     components:
     - pos: 24.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2601
     components:
     - pos: 25.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2602
     components:
     - pos: 26.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2603
     components:
     - pos: 27.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2604
     components:
     - pos: 28.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2605
     components:
     - pos: 29.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2606
     components:
     - pos: 30.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2607
     components:
     - pos: 31.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2608
     components:
     - pos: 32.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2609
     components:
     - pos: 33.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2610
     components:
     - pos: 34.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2611
     components:
     - pos: 33.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2612
     components:
     - pos: 28.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2613
     components:
     - pos: 20.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2614
     components:
     - pos: 23.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2615
     components:
     - pos: 23.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2616
     components:
     - pos: 23.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2617
     components:
     - pos: 23.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2618
     components:
     - pos: 23.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2619
     components:
     - pos: 23.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2620
     components:
     - pos: 24.5,17.5
@@ -9520,8 +8260,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2621
     components:
     - pos: 24.5,16.5
@@ -9529,8 +8267,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2622
     components:
     - pos: 24.5,15.5
@@ -9538,8 +8274,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2623
     components:
     - pos: 24.5,19.5
@@ -9547,8 +8281,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2624
     components:
     - pos: 24.5,14.5
@@ -9556,78 +8288,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2625
     components:
     - pos: 24.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2626
     components:
     - pos: 25.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2627
     components:
     - pos: 26.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2628
     components:
     - pos: 27.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2629
     components:
     - pos: 28.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2630
     components:
     - pos: 29.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2631
     components:
     - pos: 30.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2632
     components:
     - pos: 31.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2633
     components:
     - pos: 32.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2634
     components:
     - pos: 33.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2635
     components:
     - pos: 33.5,14.5
@@ -9635,8 +8345,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2636
     components:
     - pos: 31.5,14.5
@@ -9644,8 +8352,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2637
     components:
     - pos: 30.5,14.5
@@ -9653,8 +8359,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2638
     components:
     - pos: 29.5,14.5
@@ -9662,8 +8366,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2639
     components:
     - pos: 27.5,14.5
@@ -9671,8 +8373,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2640
     components:
     - pos: 26.5,14.5
@@ -9680,8 +8380,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2641
     components:
     - pos: 25.5,14.5
@@ -9689,225 +8387,161 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2642
     components:
     - pos: 28.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2643
     components:
     - pos: 28.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2644
     components:
     - pos: 28.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2645
     components:
     - pos: 28.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2646
     components:
     - pos: 28.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2647
     components:
     - pos: 29.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2648
     components:
     - pos: 30.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2649
     components:
     - pos: 31.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2650
     components:
     - pos: 27.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2651
     components:
     - pos: 26.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2652
     components:
     - pos: 25.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2653
     components:
     - pos: 27.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2654
     components:
     - pos: 26.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2655
     components:
     - pos: 29.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2656
     components:
     - pos: 30.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2657
     components:
     - pos: 24.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2658
     components:
     - pos: 23.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2659
     components:
     - pos: 22.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2660
     components:
     - pos: 33.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2661
     components:
     - pos: 34.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2662
     components:
     - pos: 33.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2663
     components:
     - pos: 32.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2664
     components:
     - pos: 31.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2665
     components:
     - pos: 30.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2666
     components:
     - pos: 29.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2667
     components:
     - pos: 28.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2668
     components:
     - pos: 27.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2669
     components:
     - pos: 26.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2670
     components:
     - pos: 25.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2671
     components:
     - pos: 24.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2672
     components:
     - pos: 23.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2673
     components:
     - pos: 35.5,19.5
@@ -9915,43 +8549,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2674
     components:
     - pos: 34.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2675
     components:
     - pos: 33.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2676
     components:
     - pos: 33.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2677
     components:
     - pos: 33.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2678
     components:
     - pos: 33.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2679
     components:
     - pos: 7.5,16.5
@@ -9959,50 +8581,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2680
     components:
     - pos: 7.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2681
     components:
     - pos: 7.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2682
     components:
     - pos: 7.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2683
     components:
     - pos: 7.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2684
     components:
     - pos: 7.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2685
     components:
     - pos: 6.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2686
     components:
     - pos: 5.5,12.5
@@ -10010,15 +8618,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2687
     components:
     - pos: 6.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2688
     components:
     - pos: 5.5,14.5
@@ -10026,99 +8630,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2689
     components:
     - pos: 8.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2690
     components:
     - pos: 9.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2691
     components:
     - pos: 10.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2692
     components:
     - pos: 11.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2693
     components:
     - pos: 12.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2694
     components:
     - pos: 8.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2695
     components:
     - pos: 9.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2696
     components:
     - pos: 10.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2697
     components:
     - pos: 11.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2698
     components:
     - pos: 12.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2699
     components:
     - pos: 13.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2700
     components:
     - pos: 13.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2701
     components:
     - pos: 14.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2702
     components:
     - pos: 14.5,16.5
@@ -10126,8 +8702,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2703
     components:
     - pos: 14.5,17.5
@@ -10135,8 +8709,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2704
     components:
     - pos: 14.5,18.5
@@ -10144,8 +8716,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2705
     components:
     - pos: 15.5,18.5
@@ -10153,50 +8723,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2706
     components:
     - pos: 13.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2707
     components:
     - pos: 13.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2708
     components:
     - pos: 13.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2709
     components:
     - pos: 10.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2711
     components:
     - pos: 10.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2743
     components:
     - pos: 10.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3033
     components:
     - pos: 7.5,30.5
@@ -10204,134 +8760,96 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3034
     components:
     - pos: 8.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3035
     components:
     - pos: 9.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3036
     components:
     - pos: 9.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3037
     components:
     - pos: 10.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3038
     components:
     - pos: 11.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3039
     components:
     - pos: 12.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3040
     components:
     - pos: 13.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3041
     components:
     - pos: 14.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3042
     components:
     - pos: 15.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3043
     components:
     - pos: 8.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3044
     components:
     - pos: 7.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3045
     components:
     - pos: 6.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3046
     components:
     - pos: 5.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3047
     components:
     - pos: 4.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3048
     components:
     - pos: 3.5,31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3049
     components:
     - pos: 9.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3050
     components:
     - pos: 9.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3051
     components:
     - pos: 8.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3052
     components:
     - pos: 7.5,29.5
@@ -10339,15 +8857,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3053
     components:
     - pos: 10.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3054
     components:
     - pos: 11.5,29.5
@@ -10355,8 +8869,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3055
     components:
     - pos: 9.5,26.5
@@ -10364,22 +8876,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3056
     components:
     - pos: 9.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3057
     components:
     - pos: 8.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3058
     components:
     - pos: 8.5,26.5
@@ -10387,8 +8893,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3059
     components:
     - pos: 7.5,26.5
@@ -10396,8 +8900,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3060
     components:
     - pos: 7.5,27.5
@@ -10405,15 +8907,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3061
     components:
     - pos: 10.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3062
     components:
     - pos: 10.5,26.5
@@ -10421,8 +8919,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3063
     components:
     - pos: 11.5,26.5
@@ -10430,8 +8926,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3064
     components:
     - pos: 11.5,27.5
@@ -10439,36 +8933,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3065
     components:
     - pos: 9.5,24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3066
     components:
     - pos: 9.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3067
     components:
     - pos: 9.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3068
     components:
     - pos: 8.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3069
     components:
     - pos: 7.5,22.5
@@ -10476,8 +8960,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3070
     components:
     - pos: 7.5,21.5
@@ -10485,8 +8967,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3071
     components:
     - pos: 7.5,18.5
@@ -10494,36 +8974,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3072
     components:
     - pos: 6.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3073
     components:
     - pos: 5.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3074
     components:
     - pos: 8.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3075
     components:
     - pos: 9.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3076
     components:
     - pos: 10.5,18.5
@@ -10531,8 +9001,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3077
     components:
     - pos: 10.5,17.5
@@ -10540,8 +9008,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3078
     components:
     - pos: 10.5,16.5
@@ -10549,8 +9015,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3080
     components:
     - pos: 8.5,16.5
@@ -10558,8 +9022,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3081
     components:
     - pos: 8.5,20.5
@@ -10567,190 +9029,136 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3082
     components:
     - pos: 8.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3083
     components:
     - pos: 11.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3084
     components:
     - pos: 12.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3085
     components:
     - pos: 13.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3086
     components:
     - pos: 14.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3087
     components:
     - pos: 15.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3088
     components:
     - pos: 11.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3089
     components:
     - pos: 12.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3090
     components:
     - pos: 13.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3091
     components:
     - pos: 14.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3092
     components:
     - pos: 15.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3093
     components:
     - pos: 13.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3094
     components:
     - pos: 13.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3095
     components:
     - pos: 13.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3096
     components:
     - pos: 14.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3097
     components:
     - pos: 15.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3098
     components:
     - pos: 7.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3099
     components:
     - pos: 6.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3100
     components:
     - pos: 5.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3101
     components:
     - pos: 4.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3102
     components:
     - pos: 3.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3103
     components:
     - pos: 5.5,26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3104
     components:
     - pos: 5.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3105
     components:
     - pos: 5.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3106
     components:
     - pos: 4.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3107
     components:
     - pos: 3.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3108
     components:
     - pos: 4.5,24.5
@@ -10758,8 +9166,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3109
     components:
     - pos: 4.5,27.5
@@ -10767,8 +9173,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3110
     components:
     - pos: 14.5,27.5
@@ -10776,8 +9180,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3111
     components:
     - pos: 14.5,24.5
@@ -10785,8 +9187,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3112
     components:
     - pos: 14.5,21.5
@@ -10794,8 +9194,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3113
     components:
     - pos: 6.5,30.5
@@ -10803,8 +9201,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3114
     components:
     - pos: 5.5,30.5
@@ -10812,8 +9208,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3115
     components:
     - pos: 12.5,30.5
@@ -10821,8 +9215,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3116
     components:
     - pos: 13.5,30.5
@@ -10830,15 +9222,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3467
     components:
     - pos: -22.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3468
     components:
     - pos: -22.5,13.5
@@ -10846,99 +9234,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3469
     components:
     - pos: -21.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3470
     components:
     - pos: -21.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3471
     components:
     - pos: -21.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3472
     components:
     - pos: -21.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3473
     components:
     - pos: -21.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3474
     components:
     - pos: -21.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3475
     components:
     - pos: -20.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3476
     components:
     - pos: -19.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3477
     components:
     - pos: -22.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3478
     components:
     - pos: -23.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3479
     components:
     - pos: -24.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3480
     components:
     - pos: -25.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3481
     components:
     - pos: -26.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3482
     components:
     - pos: -27.5,11.5
@@ -10946,8 +9306,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3483
     components:
     - pos: -27.5,12.5
@@ -10955,29 +9313,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3484
     components:
     - pos: -25.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3485
     components:
     - pos: -25.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3486
     components:
     - pos: -26.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3487
     components:
     - pos: -27.5,9.5
@@ -10985,8 +9335,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3488
     components:
     - pos: -27.5,8.5
@@ -10994,8 +9342,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3489
     components:
     - pos: -22.5,7.5
@@ -11003,106 +9349,76 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3490
     components:
     - pos: -22.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3491
     components:
     - pos: -22.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3492
     components:
     - pos: -22.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3493
     components:
     - pos: -22.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3494
     components:
     - pos: -22.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3495
     components:
     - pos: -21.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3496
     components:
     - pos: -20.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3497
     components:
     - pos: -19.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3498
     components:
     - pos: -18.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3499
     components:
     - pos: -21.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3500
     components:
     - pos: -20.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3501
     components:
     - pos: -19.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3502
     components:
     - pos: -23.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3503
     components:
     - pos: -23.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3504
     components:
     - pos: -13.5,6.5
@@ -11110,8 +9426,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3505
     components:
     - pos: -14.5,6.5
@@ -11119,57 +9433,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3506
     components:
     - pos: -14.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3507
     components:
     - pos: -12.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3508
     components:
     - pos: -12.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3509
     components:
     - pos: -11.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3510
     components:
     - pos: -15.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3511
     components:
     - pos: -16.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3512
     components:
     - pos: -10.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3513
     components:
     - pos: -16.5,13.5
@@ -11177,71 +9475,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3514
     components:
     - pos: -16.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3515
     components:
     - pos: -15.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3516
     components:
     - pos: -15.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3517
     components:
     - pos: -15.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3518
     components:
     - pos: -15.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3519
     components:
     - pos: -20.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3520
     components:
     - pos: -19.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3521
     components:
     - pos: -22.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3522
     components:
     - pos: -23.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3991
     components:
     - pos: -31.5,2.5
@@ -11249,43 +9527,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3992
     components:
     - pos: -31.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3993
     components:
     - pos: -31.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3994
     components:
     - pos: -31.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3995
     components:
     - pos: -31.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3996
     components:
     - pos: -31.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3997
     components:
     - pos: -32.5,-2.5
@@ -11293,8 +9559,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3998
     components:
     - pos: -33.5,-2.5
@@ -11302,8 +9566,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3999
     components:
     - pos: -34.5,-2.5
@@ -11311,8 +9573,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4000
     components:
     - pos: -32.5,-0.5
@@ -11320,8 +9580,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4001
     components:
     - pos: -33.5,-0.5
@@ -11329,8 +9587,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4002
     components:
     - pos: -34.5,-0.5
@@ -11338,8 +9594,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4003
     components:
     - pos: -32.5,1.5
@@ -11347,8 +9601,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4004
     components:
     - pos: -33.5,1.5
@@ -11356,8 +9608,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4005
     components:
     - pos: -34.5,1.5
@@ -11365,22 +9615,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4006
     components:
     - pos: -30.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4007
     components:
     - pos: -29.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4008
     components:
     - pos: -28.5,-0.5
@@ -11388,8 +9632,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4009
     components:
     - pos: -26.5,-0.5
@@ -11397,120 +9639,86 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4010
     components:
     - pos: -25.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4011
     components:
     - pos: -24.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4012
     components:
     - pos: -23.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4013
     components:
     - pos: -22.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4014
     components:
     - pos: -21.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4015
     components:
     - pos: -20.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4016
     components:
     - pos: -19.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4017
     components:
     - pos: -18.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4018
     components:
     - pos: -17.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4019
     components:
     - pos: -16.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4020
     components:
     - pos: -15.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4021
     components:
     - pos: -14.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4022
     components:
     - pos: -13.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4023
     components:
     - pos: -12.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4024
     components:
     - pos: -11.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4025
     components:
     - pos: -10.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4026
     components:
     - pos: -9.5,-0.5
@@ -11518,15 +9726,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4027
     components:
     - pos: -14.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4028
     components:
     - pos: -14.5,1.5
@@ -11534,8 +9738,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4029
     components:
     - pos: -15.5,1.5
@@ -11543,8 +9745,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4030
     components:
     - pos: -16.5,1.5
@@ -11552,15 +9752,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4031
     components:
     - pos: -12.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4032
     components:
     - pos: -12.5,1.5
@@ -11568,8 +9764,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4033
     components:
     - pos: -11.5,1.5
@@ -11577,8 +9771,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4034
     components:
     - pos: -10.5,1.5
@@ -11586,8 +9778,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4035
     components:
     - pos: -13.5,1.5
@@ -11595,8 +9785,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4036
     components:
     - pos: -13.5,2.5
@@ -11604,15 +9792,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4037
     components:
     - pos: -17.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4038
     components:
     - pos: -17.5,1.5
@@ -11620,8 +9804,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4039
     components:
     - pos: -21.5,-2.5
@@ -11629,218 +9811,156 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4040
     components:
     - pos: -21.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4041
     components:
     - pos: -21.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4042
     components:
     - pos: -21.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4043
     components:
     - pos: -21.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4044
     components:
     - pos: -21.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4045
     components:
     - pos: -21.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4046
     components:
     - pos: -22.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4047
     components:
     - pos: -23.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4048
     components:
     - pos: -24.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4049
     components:
     - pos: -25.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4050
     components:
     - pos: -26.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4051
     components:
     - pos: -26.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4052
     components:
     - pos: -26.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4053
     components:
     - pos: -25.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4054
     components:
     - pos: -24.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4055
     components:
     - pos: -23.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4056
     components:
     - pos: -22.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4057
     components:
     - pos: -20.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4058
     components:
     - pos: -19.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4059
     components:
     - pos: -18.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4060
     components:
     - pos: -17.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4061
     components:
     - pos: -17.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4062
     components:
     - pos: -17.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4063
     components:
     - pos: -18.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4064
     components:
     - pos: -19.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4065
     components:
     - pos: -20.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4066
     components:
     - pos: -26.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4067
     components:
     - pos: -26.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4068
     components:
     - pos: -17.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4069
     components:
     - pos: -17.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4070
     components:
     - pos: -13.5,-2.5
@@ -11848,106 +9968,76 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4071
     components:
     - pos: -13.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4072
     components:
     - pos: -13.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4073
     components:
     - pos: -13.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4074
     components:
     - pos: -13.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4075
     components:
     - pos: -13.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4076
     components:
     - pos: -13.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4077
     components:
     - pos: -12.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4078
     components:
     - pos: -11.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4079
     components:
     - pos: -12.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4080
     components:
     - pos: -11.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4081
     components:
     - pos: -14.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4082
     components:
     - pos: -14.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4083
     components:
     - pos: -11.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4084
     components:
     - pos: -12.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4085
     components:
     - pos: -31.5,7.5
@@ -11955,43 +10045,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4086
     components:
     - pos: -31.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4087
     components:
     - pos: -31.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4088
     components:
     - pos: -31.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4089
     components:
     - pos: -32.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4090
     components:
     - pos: -33.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4091
     components:
     - pos: -34.5,4.5
@@ -11999,8 +10077,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4092
     components:
     - pos: -34.5,3.5
@@ -12008,8 +10084,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4093
     components:
     - pos: -34.5,5.5
@@ -12017,8 +10091,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4094
     components:
     - pos: -34.5,6.5
@@ -12026,15 +10098,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4095
     components:
     - pos: -32.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4096
     components:
     - pos: -32.5,7.5
@@ -12042,8 +10110,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4097
     components:
     - pos: -33.5,7.5
@@ -12051,8 +10117,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4098
     components:
     - pos: -30.5,7.5
@@ -12060,29 +10124,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4099
     components:
     - pos: -30.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4100
     components:
     - pos: -29.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4101
     components:
     - pos: -28.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4102
     components:
     - pos: -27.5,4.5
@@ -12090,8 +10146,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4103
     components:
     - pos: -27.5,3.5
@@ -12099,8 +10153,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4104
     components:
     - pos: -27.5,5.5
@@ -12108,8 +10160,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4481
     components:
     - pos: 1.5,-20.5
@@ -12117,99 +10167,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4482
     components:
     - pos: 1.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4483
     components:
     - pos: 1.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4484
     components:
     - pos: 1.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4485
     components:
     - pos: 1.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4486
     components:
     - pos: 0.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4487
     components:
     - pos: -0.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4488
     components:
     - pos: -1.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4489
     components:
     - pos: -2.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4490
     components:
     - pos: -3.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4491
     components:
     - pos: -10.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4492
     components:
     - pos: -5.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4493
     components:
     - pos: -4.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4494
     components:
     - pos: -4.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4495
     components:
     - pos: -8.5,-24.5
@@ -12217,50 +10239,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4496
     components:
     - pos: -9.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4497
     components:
     - pos: 3.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4498
     components:
     - pos: 3.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4499
     components:
     - pos: 4.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4500
     components:
     - pos: -1.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4501
     components:
     - pos: -1.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4502
     components:
     - pos: 2.5,-17.5
@@ -12268,15 +10276,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4503
     components:
     - pos: 3.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4504
     components:
     - pos: 2.5,-15.5
@@ -12284,15 +10288,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4505
     components:
     - pos: -4.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4506
     components:
     - pos: -3.5,-15.5
@@ -12300,8 +10300,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4507
     components:
     - pos: -3.5,-17.5
@@ -12309,8 +10307,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4508
     components:
     - pos: -5.5,-17.5
@@ -12318,8 +10314,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4509
     components:
     - pos: 4.5,-17.5
@@ -12327,57 +10321,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4510
     components:
     - pos: -10.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4511
     components:
     - pos: -10.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4512
     components:
     - pos: -10.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4513
     components:
     - pos: -10.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4514
     components:
     - pos: -10.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4515
     components:
     - pos: -9.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4516
     components:
     - pos: -8.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4517
     components:
     - pos: 7.5,-24.5
@@ -12385,71 +10363,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4518
     components:
     - pos: 8.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4519
     components:
     - pos: 9.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4520
     components:
     - pos: 9.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4521
     components:
     - pos: 9.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4522
     components:
     - pos: 9.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4523
     components:
     - pos: 9.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4524
     components:
     - pos: 9.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4525
     components:
     - pos: 8.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4526
     components:
     - pos: 7.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4527
     components:
     - pos: -2.5,-24.5
@@ -12457,197 +10415,141 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4528
     components:
     - pos: -2.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4529
     components:
     - pos: -2.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4530
     components:
     - pos: -2.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4531
     components:
     - pos: -1.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4532
     components:
     - pos: -0.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4533
     components:
     - pos: 0.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4534
     components:
     - pos: 1.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4535
     components:
     - pos: 2.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4536
     components:
     - pos: 3.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4537
     components:
     - pos: 4.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4538
     components:
     - pos: 5.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4539
     components:
     - pos: -4.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4540
     components:
     - pos: -3.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4541
     components:
     - pos: -5.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4542
     components:
     - pos: -6.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4543
     components:
     - pos: 5.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4544
     components:
     - pos: -6.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4545
     components:
     - pos: -6.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4546
     components:
     - pos: 5.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4547
     components:
     - pos: -0.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4548
     components:
     - pos: -0.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4549
     components:
     - pos: -0.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4550
     components:
     - pos: -0.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4551
     components:
     - pos: -0.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4552
     components:
     - pos: -0.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4553
     components:
     - pos: 2.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4554
     components:
     - pos: -1.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4555
     components:
     - pos: -2.5,-22.5
@@ -12655,8 +10557,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4556
     components:
     - pos: -2.5,-23.5
@@ -12664,8 +10564,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4557
     components:
     - pos: -2.5,-21.5
@@ -12673,15 +10571,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4558
     components:
     - pos: -3.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4559
     components:
     - pos: -4.5,-22.5
@@ -12689,8 +10583,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4560
     components:
     - pos: -4.5,-23.5
@@ -12698,8 +10590,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4561
     components:
     - pos: -4.5,-21.5
@@ -12707,8 +10597,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4562
     components:
     - pos: 1.5,-21.5
@@ -12716,8 +10604,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4563
     components:
     - pos: 1.5,-22.5
@@ -12725,8 +10611,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4564
     components:
     - pos: 1.5,-23.5
@@ -12734,8 +10618,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4565
     components:
     - pos: 3.5,-22.5
@@ -12743,8 +10625,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4566
     components:
     - pos: 3.5,-21.5
@@ -12752,8 +10632,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4567
     components:
     - pos: 3.5,-23.5
@@ -12761,8 +10639,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4898
     components:
     - pos: 8.5,-17.5
@@ -12770,85 +10646,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4899
     components:
     - pos: 8.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4900
     components:
     - pos: 8.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4901
     components:
     - pos: 9.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4902
     components:
     - pos: 10.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4903
     components:
     - pos: 11.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4904
     components:
     - pos: 12.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4905
     components:
     - pos: 13.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4906
     components:
     - pos: 7.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4907
     components:
     - pos: 6.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4908
     components:
     - pos: 6.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4909
     components:
     - pos: 6.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4910
     components:
     - pos: -9.5,-17.5
@@ -12856,92 +10708,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4911
     components:
     - pos: -9.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4912
     components:
     - pos: -8.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4913
     components:
     - pos: -8.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4914
     components:
     - pos: -8.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4915
     components:
     - pos: -9.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4916
     components:
     - pos: -10.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4917
     components:
     - pos: -11.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4918
     components:
     - pos: -12.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4919
     components:
     - pos: -13.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4920
     components:
     - pos: -13.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4921
     components:
     - pos: -13.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4922
     components:
     - pos: -13.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4993
     components:
     - pos: 18.5,-19.5
@@ -12949,36 +10775,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4994
     components:
     - pos: 18.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4995
     components:
     - pos: 17.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4996
     components:
     - pos: 16.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4997
     components:
     - pos: 16.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4998
     components:
     - pos: 16.5,-18.5
@@ -12986,8 +10802,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4999
     components:
     - pos: 20.5,-12.5
@@ -12995,43 +10809,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5000
     components:
     - pos: 20.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5001
     components:
     - pos: 20.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5002
     components:
     - pos: 20.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5003
     components:
     - pos: 19.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5004
     components:
     - pos: 19.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5005
     components:
     - pos: 18.5,-14.5
@@ -13039,15 +10841,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5006
     components:
     - pos: 17.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5007
     components:
     - pos: 16.5,-14.5
@@ -13055,8 +10853,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5008
     components:
     - pos: 15.5,-14.5
@@ -13064,85 +10860,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5009
     components:
     - pos: 21.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5010
     components:
     - pos: 22.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5011
     components:
     - pos: 19.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5012
     components:
     - pos: 20.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5013
     components:
     - pos: 21.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5014
     components:
     - pos: 21.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5015
     components:
     - pos: 21.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5016
     components:
     - pos: 21.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5017
     components:
     - pos: 21.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5018
     components:
     - pos: 21.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5019
     components:
     - pos: 16.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5020
     components:
     - pos: 16.5,-22.5
@@ -13150,141 +10922,101 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5021
     components:
     - pos: 16.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5022
     components:
     - pos: 16.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5023
     components:
     - pos: 16.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5024
     components:
     - pos: 16.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5026
     components:
     - pos: 15.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5027
     components:
     - pos: 14.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5028
     components:
     - pos: 13.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5029
     components:
     - pos: 13.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5030
     components:
     - pos: 13.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5031
     components:
     - pos: 13.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5032
     components:
     - pos: 13.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5033
     components:
     - pos: 13.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5034
     components:
     - pos: 13.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5035
     components:
     - pos: 13.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5036
     components:
     - pos: 17.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5037
     components:
     - pos: 18.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5038
     components:
     - pos: 19.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5039
     components:
     - pos: 20.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5040
     components:
     - pos: 21.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5121
     components:
     - pos: 34.5,-9.5
@@ -13292,85 +11024,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5122
     components:
     - pos: 34.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5123
     components:
     - pos: 34.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5124
     components:
     - pos: 34.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5125
     components:
     - pos: 34.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5126
     components:
     - pos: 33.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5127
     components:
     - pos: 32.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5128
     components:
     - pos: 32.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5129
     components:
     - pos: 31.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5130
     components:
     - pos: 30.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5131
     components:
     - pos: 30.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5132
     components:
     - pos: 30.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5134
     components:
     - pos: 22.5,-23.5
@@ -13378,85 +11086,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5135
     components:
     - pos: 23.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5136
     components:
     - pos: 24.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5137
     components:
     - pos: 25.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5138
     components:
     - pos: 26.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5139
     components:
     - pos: 25.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5140
     components:
     - pos: 25.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5141
     components:
     - pos: 25.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5142
     components:
     - pos: 25.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5143
     components:
     - pos: 25.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5144
     components:
     - pos: 25.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5145
     components:
     - pos: 25.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5147
     components:
     - pos: 29.5,-19.5
@@ -13464,50 +11148,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5148
     components:
     - pos: 29.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5149
     components:
     - pos: 29.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5150
     components:
     - pos: 29.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5151
     components:
     - pos: 29.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5152
     components:
     - pos: 29.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5153
     components:
     - pos: 29.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5154
     components:
     - pos: 28.5,-25.5
@@ -13515,8 +11185,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5155
     components:
     - pos: 28.5,-24.5
@@ -13524,8 +11192,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5156
     components:
     - pos: 28.5,-23.5
@@ -13533,8 +11199,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5157
     components:
     - pos: 28.5,-22.5
@@ -13542,8 +11206,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5158
     components:
     - pos: 28.5,-21.5
@@ -13551,8 +11213,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5159
     components:
     - pos: 30.5,-25.5
@@ -13560,8 +11220,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5160
     components:
     - pos: 31.5,-25.5
@@ -13569,8 +11227,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5161
     components:
     - pos: 32.5,-25.5
@@ -13578,8 +11234,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5162
     components:
     - pos: 33.5,-25.5
@@ -13587,8 +11241,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5163
     components:
     - pos: 30.5,-21.5
@@ -13596,8 +11248,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5164
     components:
     - pos: 31.5,-21.5
@@ -13605,8 +11255,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5165
     components:
     - pos: 32.5,-21.5
@@ -13614,8 +11262,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5166
     components:
     - pos: 33.5,-21.5
@@ -13623,15 +11269,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5171
     components:
     - pos: 31.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5172
     components:
     - pos: 31.5,-19.5
@@ -13639,15 +11281,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5173
     components:
     - pos: 33.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5174
     components:
     - pos: 33.5,-19.5
@@ -13655,8 +11293,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5258
     components:
     - pos: 30.5,-14.5
@@ -13664,92 +11300,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5259
     components:
     - pos: 30.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5260
     components:
     - pos: 30.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5261
     components:
     - pos: 30.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5262
     components:
     - pos: 31.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5263
     components:
     - pos: 32.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5264
     components:
     - pos: 33.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5265
     components:
     - pos: 29.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5266
     components:
     - pos: 28.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5267
     components:
     - pos: 27.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5268
     components:
     - pos: 26.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5269
     components:
     - pos: 25.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5270
     components:
     - pos: 24.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5271
     components:
     - pos: 24.5,-16.5
@@ -13757,22 +11367,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5272
     components:
     - pos: 24.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5273
     components:
     - pos: 24.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5274
     components:
     - pos: 27.5,-16.5
@@ -13780,22 +11384,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5275
     components:
     - pos: 27.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5276
     components:
     - pos: 27.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5441
     components:
     - pos: 15.5,-22.5
@@ -13803,8 +11401,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5442
     components:
     - pos: 17.5,-22.5
@@ -13812,8 +11408,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5443
     components:
     - pos: 16.5,-28.5
@@ -13821,36 +11415,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5444
     components:
     - pos: 16.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5445
     components:
     - pos: 16.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5446
     components:
     - pos: 16.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5447
     components:
     - pos: 17.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5448
     components:
     - pos: 18.5,-30.5
@@ -13858,8 +11442,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5449
     components:
     - pos: 18.5,-31.5
@@ -13867,8 +11449,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5450
     components:
     - pos: 18.5,-29.5
@@ -13876,15 +11456,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5585
     components:
     - pos: 21.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5935
     components:
     - pos: -16.5,-30.5
@@ -13892,29 +11468,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5936
     components:
     - pos: -16.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5937
     components:
     - pos: -16.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5938
     components:
     - pos: -16.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5939
     components:
     - pos: -17.5,-33.5
@@ -13922,8 +11490,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5940
     components:
     - pos: -18.5,-33.5
@@ -13931,8 +11497,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6067
     components:
     - pos: -17.5,-22.5
@@ -13940,71 +11504,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6068
     components:
     - pos: -18.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6069
     components:
     - pos: -19.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6070
     components:
     - pos: -19.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6071
     components:
     - pos: -19.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6072
     components:
     - pos: -19.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6073
     components:
     - pos: -19.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6074
     components:
     - pos: -19.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6075
     components:
     - pos: -19.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6076
     components:
     - pos: -20.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6077
     components:
     - pos: -21.5,-26.5
@@ -14012,8 +11556,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6078
     components:
     - pos: -22.5,-26.5
@@ -14021,15 +11563,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6079
     components:
     - pos: -20.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6080
     components:
     - pos: -21.5,-24.5
@@ -14037,8 +11575,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6081
     components:
     - pos: -22.5,-24.5
@@ -14046,8 +11582,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6082
     components:
     - pos: -19.5,-21.5
@@ -14055,8 +11589,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6083
     components:
     - pos: -18.5,-21.5
@@ -14064,8 +11596,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6084
     components:
     - pos: -20.5,-21.5
@@ -14073,8 +11603,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6085
     components:
     - pos: -21.5,-23.5
@@ -14082,8 +11610,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6086
     components:
     - pos: -21.5,-25.5
@@ -14091,8 +11617,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6087
     components:
     - pos: -21.5,-27.5
@@ -14100,8 +11624,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6088
     components:
     - pos: -22.5,-25.5
@@ -14109,8 +11631,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6089
     components:
     - pos: -23.5,-25.5
@@ -14118,8 +11638,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6090
     components:
     - pos: -23.5,-26.5
@@ -14127,8 +11645,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6091
     components:
     - pos: -23.5,-27.5
@@ -14136,8 +11652,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6092
     components:
     - pos: -23.5,-23.5
@@ -14145,8 +11659,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6093
     components:
     - pos: -23.5,-24.5
@@ -14154,8 +11666,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6094
     components:
     - pos: -18.5,-34.5
@@ -14163,8 +11673,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6095
     components:
     - pos: -17.5,-34.5
@@ -14172,8 +11680,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6096
     components:
     - pos: -19.5,-34.5
@@ -14181,8 +11687,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6097
     components:
     - pos: -19.5,-33.5
@@ -14190,8 +11694,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6098
     components:
     - pos: -20.5,-33.5
@@ -14199,8 +11701,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6099
     components:
     - pos: -20.5,-32.5
@@ -14208,8 +11708,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6100
     components:
     - pos: -20.5,-31.5
@@ -14217,8 +11715,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6112
     components:
     - pos: -15.5,-28.5
@@ -14226,148 +11722,106 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6113
     components:
     - pos: -14.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6114
     components:
     - pos: -13.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6115
     components:
     - pos: -13.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6116
     components:
     - pos: -13.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6117
     components:
     - pos: -13.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6118
     components:
     - pos: -13.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6119
     components:
     - pos: -13.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6120
     components:
     - pos: -13.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6121
     components:
     - pos: -13.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6122
     components:
     - pos: -13.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6123
     components:
     - pos: -13.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6124
     components:
     - pos: -13.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6125
     components:
     - pos: -13.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6126
     components:
     - pos: -13.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6127
     components:
     - pos: 15.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6128
     components:
     - pos: 14.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6129
     components:
     - pos: 13.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6131
     components:
     - pos: 13.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6132
     components:
     - pos: 13.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6133
     components:
     - pos: -0.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6134
     components:
     - pos: -0.5,-30.5
@@ -14375,8 +11829,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6135
     components:
     - pos: -1.5,-30.5
@@ -14384,8 +11836,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6136
     components:
     - pos: 0.5,-30.5
@@ -14393,8 +11843,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6202
     components:
     - pos: -8.5,-30.5
@@ -14402,78 +11850,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6203
     components:
     - pos: -8.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6204
     components:
     - pos: -8.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6205
     components:
     - pos: -8.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6206
     components:
     - pos: -7.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6207
     components:
     - pos: -6.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6208
     components:
     - pos: -5.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6209
     components:
     - pos: -4.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6210
     components:
     - pos: -9.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6211
     components:
     - pos: -10.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6212
     components:
     - pos: -11.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6213
     components:
     - pos: 7.5,-30.5
@@ -14481,92 +11907,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6214
     components:
     - pos: 7.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6215
     components:
     - pos: 7.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6216
     components:
     - pos: 7.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6217
     components:
     - pos: 6.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6218
     components:
     - pos: 5.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6219
     components:
     - pos: 4.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6220
     components:
     - pos: 3.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6221
     components:
     - pos: 8.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6222
     components:
     - pos: 9.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6223
     components:
     - pos: 10.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6224
     components:
     - pos: 11.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6225
     components:
     - pos: 12.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6346
     components:
     - pos: -2.5,-34.5
@@ -14574,99 +11974,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6347
     components:
     - pos: -2.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6348
     components:
     - pos: -2.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6349
     components:
     - pos: -2.5,-37.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6350
     components:
     - pos: -1.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6351
     components:
     - pos: -0.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6352
     components:
     - pos: 0.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6353
     components:
     - pos: 1.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6354
     components:
     - pos: 2.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6355
     components:
     - pos: 3.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6356
     components:
     - pos: -3.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6357
     components:
     - pos: -4.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6358
     components:
     - pos: -5.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6359
     components:
     - pos: -0.5,-37.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6360
     components:
     - pos: -0.5,-38.5
@@ -14674,8 +12046,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6409
     components:
     - pos: -2.5,-40.5
@@ -14683,134 +12053,96 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6410
     components:
     - pos: -2.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6411
     components:
     - pos: -2.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6412
     components:
     - pos: -2.5,-43.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6413
     components:
     - pos: -1.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6414
     components:
     - pos: -0.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6415
     components:
     - pos: 0.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6416
     components:
     - pos: 1.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6417
     components:
     - pos: 2.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6418
     components:
     - pos: 3.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6419
     components:
     - pos: 4.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6420
     components:
     - pos: 4.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6421
     components:
     - pos: 4.5,-40.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6422
     components:
     - pos: -3.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6423
     components:
     - pos: -4.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6424
     components:
     - pos: -5.5,-42.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6425
     components:
     - pos: -5.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6426
     components:
     - pos: -5.5,-40.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6427
     components:
     - pos: -0.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6428
     components:
     - pos: -0.5,-40.5
@@ -14818,15 +12150,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6429
     components:
     - pos: -0.5,-43.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6430
     components:
     - pos: -0.5,-44.5
@@ -14834,8 +12162,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6431
     components:
     - pos: -0.5,-45.5
@@ -14843,8 +12169,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6432
     components:
     - pos: -0.5,-46.5
@@ -14852,8 +12176,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6433
     components:
     - pos: -2.5,-44.5
@@ -14861,8 +12183,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6434
     components:
     - pos: -2.5,-45.5
@@ -14870,8 +12190,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6435
     components:
     - pos: -2.5,-46.5
@@ -14879,8 +12197,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6436
     components:
     - pos: 1.5,-44.5
@@ -14888,15 +12204,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6437
     components:
     - pos: 1.5,-43.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6438
     components:
     - pos: 1.5,-45.5
@@ -14904,8 +12216,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6439
     components:
     - pos: 1.5,-46.5
@@ -14913,8 +12223,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
 - proto: CableHV
   entities:
   - uid: 1475
@@ -14924,8 +12232,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1476
     components:
     - pos: 16.5,-13.5
@@ -14933,22 +12239,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1477
     components:
     - pos: 17.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1478
     components:
     - pos: 17.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1479
     components:
     - pos: 18.5,-14.5
@@ -14956,15 +12256,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1480
     components:
     - pos: 19.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1864
     components:
     - pos: -3.5,20.5
@@ -14972,8 +12268,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1865
     components:
     - pos: -2.5,20.5
@@ -14981,8 +12275,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1866
     components:
     - pos: -1.5,20.5
@@ -14990,8 +12282,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1867
     components:
     - pos: -0.5,20.5
@@ -14999,8 +12289,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1868
     components:
     - pos: 0.5,20.5
@@ -15008,8 +12296,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1869
     components:
     - pos: 1.5,20.5
@@ -15017,8 +12303,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1870
     components:
     - pos: 2.5,20.5
@@ -15026,8 +12310,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1871
     components:
     - pos: -0.5,19.5
@@ -15035,8 +12317,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1872
     components:
     - pos: -0.5,18.5
@@ -15044,8 +12324,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1873
     components:
     - pos: -0.5,17.5
@@ -15053,281 +12331,201 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1874
     components:
     - pos: -0.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1875
     components:
     - pos: -0.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1876
     components:
     - pos: -0.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1877
     components:
     - pos: -0.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1878
     components:
     - pos: -0.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1879
     components:
     - pos: -0.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1880
     components:
     - pos: -0.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1881
     components:
     - pos: -0.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1882
     components:
     - pos: -0.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1883
     components:
     - pos: -0.5,7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1884
     components:
     - pos: -0.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1885
     components:
     - pos: -0.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1886
     components:
     - pos: -0.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1887
     components:
     - pos: -0.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1888
     components:
     - pos: 0.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1889
     components:
     - pos: 1.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1890
     components:
     - pos: 2.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1891
     components:
     - pos: 3.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1892
     components:
     - pos: 4.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1893
     components:
     - pos: 4.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1894
     components:
     - pos: 4.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1895
     components:
     - pos: 4.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1896
     components:
     - pos: 4.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1897
     components:
     - pos: 17.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1898
     components:
     - pos: 17.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1899
     components:
     - pos: 16.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1900
     components:
     - pos: 15.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1901
     components:
     - pos: 14.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1902
     components:
     - pos: 13.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1903
     components:
     - pos: 12.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1904
     components:
     - pos: 11.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1905
     components:
     - pos: 10.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1906
     components:
     - pos: 9.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1907
     components:
     - pos: 8.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1908
     components:
     - pos: 7.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1909
     components:
     - pos: 6.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1910
     components:
     - pos: 5.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1911
     components:
     - pos: 4.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1912
     components:
     - pos: 3.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1913
     components:
     - pos: 2.5,-11.5
@@ -15335,267 +12533,191 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1914
     components:
     - pos: 1.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1915
     components:
     - pos: 0.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1916
     components:
     - pos: -0.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1917
     components:
     - pos: -0.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1918
     components:
     - pos: -0.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1919
     components:
     - pos: -0.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1920
     components:
     - pos: -0.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1921
     components:
     - pos: -0.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1922
     components:
     - pos: -1.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1923
     components:
     - pos: -0.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1924
     components:
     - pos: 0.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1925
     components:
     - pos: 1.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1926
     components:
     - pos: 2.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1927
     components:
     - pos: 3.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1928
     components:
     - pos: 4.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1929
     components:
     - pos: 4.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1930
     components:
     - pos: 4.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1931
     components:
     - pos: 4.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1932
     components:
     - pos: 17.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1933
     components:
     - pos: 17.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1934
     components:
     - pos: 17.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1935
     components:
     - pos: 17.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1936
     components:
     - pos: 17.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1937
     components:
     - pos: 16.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1938
     components:
     - pos: 15.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1939
     components:
     - pos: 14.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1940
     components:
     - pos: 13.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1941
     components:
     - pos: 12.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1942
     components:
     - pos: 12.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1943
     components:
     - pos: 12.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1944
     components:
     - pos: 12.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1945
     components:
     - pos: 12.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1946
     components:
     - pos: 12.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1947
     components:
     - pos: 12.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1948
     components:
     - pos: 11.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1949
     components:
     - pos: 10.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1950
     components:
     - pos: 9.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1951
     components:
     - pos: 8.5,-0.5
@@ -15603,15 +12725,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1952
     components:
     - pos: 7.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1953
     components:
     - pos: 6.5,-0.5
@@ -15619,36 +12737,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1954
     components:
     - pos: 5.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2523
     components:
     - pos: 0.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2524
     components:
     - pos: 1.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2525
     components:
     - pos: 2.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2526
     components:
     - pos: 3.5,12.5
@@ -15656,15 +12764,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2527
     components:
     - pos: 4.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2528
     components:
     - pos: 5.5,12.5
@@ -15672,92 +12776,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2529
     components:
     - pos: 6.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2530
     components:
     - pos: 7.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2531
     components:
     - pos: 8.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2532
     components:
     - pos: 9.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2533
     components:
     - pos: 10.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2534
     components:
     - pos: 11.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2535
     components:
     - pos: 12.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2536
     components:
     - pos: 13.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2537
     components:
     - pos: 14.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2538
     components:
     - pos: 14.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2539
     components:
     - pos: 14.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2540
     components:
     - pos: 14.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2541
     components:
     - pos: 14.5,16.5
@@ -15765,8 +12843,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2542
     components:
     - pos: 14.5,17.5
@@ -15774,8 +12850,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2543
     components:
     - pos: 14.5,18.5
@@ -15783,8 +12857,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2544
     components:
     - pos: 15.5,18.5
@@ -15792,8 +12864,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2545
     components:
     - pos: 15.5,19.5
@@ -15801,22 +12871,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3257
     components:
     - pos: 16.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3523
     components:
     - pos: -1.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3524
     components:
     - pos: -1.5,-6.5
@@ -15824,141 +12888,101 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3525
     components:
     - pos: -1.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3526
     components:
     - pos: -2.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3527
     components:
     - pos: -3.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3528
     components:
     - pos: -4.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3529
     components:
     - pos: -5.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3530
     components:
     - pos: -6.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3531
     components:
     - pos: -2.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3532
     components:
     - pos: -3.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3533
     components:
     - pos: -4.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3534
     components:
     - pos: -5.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3535
     components:
     - pos: -6.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3536
     components:
     - pos: -6.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3537
     components:
     - pos: -6.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3538
     components:
     - pos: -6.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3539
     components:
     - pos: -6.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3540
     components:
     - pos: -6.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3541
     components:
     - pos: -6.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3542
     components:
     - pos: -6.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3543
     components:
     - pos: -6.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3544
     components:
     - pos: -7.5,-0.5
@@ -15966,15 +12990,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3545
     components:
     - pos: -8.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3546
     components:
     - pos: -9.5,-0.5
@@ -15982,183 +13002,131 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3547
     components:
     - pos: -10.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3548
     components:
     - pos: -11.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3549
     components:
     - pos: -12.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3550
     components:
     - pos: -13.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3551
     components:
     - pos: -14.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3552
     components:
     - pos: -15.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3553
     components:
     - pos: -16.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3554
     components:
     - pos: -17.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3555
     components:
     - pos: -18.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3556
     components:
     - pos: -19.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3557
     components:
     - pos: -20.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3558
     components:
     - pos: -19.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3559
     components:
     - pos: -21.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3560
     components:
     - pos: -21.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3561
     components:
     - pos: -21.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3562
     components:
     - pos: -21.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3563
     components:
     - pos: -21.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3564
     components:
     - pos: -21.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3565
     components:
     - pos: -20.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3566
     components:
     - pos: -19.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3567
     components:
     - pos: -18.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3568
     components:
     - pos: -17.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3569
     components:
     - pos: -16.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3570
     components:
     - pos: -15.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3571
     components:
     - pos: -15.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3574
     components:
     - pos: -15.5,4.5
@@ -16166,113 +13134,81 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3950
     components:
     - pos: -22.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3951
     components:
     - pos: -23.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3952
     components:
     - pos: -24.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3953
     components:
     - pos: -25.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3954
     components:
     - pos: -26.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3955
     components:
     - pos: -27.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3956
     components:
     - pos: -28.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3957
     components:
     - pos: -29.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3958
     components:
     - pos: -30.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3959
     components:
     - pos: -30.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3960
     components:
     - pos: -30.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3961
     components:
     - pos: -30.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3962
     components:
     - pos: -30.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3963
     components:
     - pos: -29.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3964
     components:
     - pos: -28.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3965
     components:
     - pos: -27.5,4.5
@@ -16280,8 +13216,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3966
     components:
     - pos: -27.5,5.5
@@ -16289,15 +13223,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3967
     components:
     - pos: -27.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4359
     components:
     - pos: 22.5,-16.5
@@ -16305,8 +13235,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4360
     components:
     - pos: 22.5,-15.5
@@ -16314,29 +13242,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4667
     components:
     - pos: 5.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4668
     components:
     - pos: 5.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4669
     components:
     - pos: 5.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4764
     components:
     - pos: 17.5,-17.5
@@ -16344,8 +13264,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4765
     components:
     - pos: 16.5,-17.5
@@ -16353,8 +13271,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4766
     components:
     - pos: 16.5,-18.5
@@ -16362,99 +13278,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4767
     components:
     - pos: 16.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4768
     components:
     - pos: 16.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4769
     components:
     - pos: 17.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4770
     components:
     - pos: 18.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4771
     components:
     - pos: 19.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4772
     components:
     - pos: 20.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4773
     components:
     - pos: 20.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4774
     components:
     - pos: 20.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4775
     components:
     - pos: 20.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4776
     components:
     - pos: 20.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4777
     components:
     - pos: 20.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4778
     components:
     - pos: 20.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4779
     components:
     - pos: 16.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4780
     components:
     - pos: 16.5,-22.5
@@ -16462,232 +13350,166 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4781
     components:
     - pos: 16.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4782
     components:
     - pos: 16.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4783
     components:
     - pos: 16.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4784
     components:
     - pos: 15.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4785
     components:
     - pos: 14.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4786
     components:
     - pos: 13.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4787
     components:
     - pos: 12.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4788
     components:
     - pos: 12.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4789
     components:
     - pos: 12.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4790
     components:
     - pos: 12.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4791
     components:
     - pos: 12.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4792
     components:
     - pos: 12.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4793
     components:
     - pos: 12.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4794
     components:
     - pos: 12.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4795
     components:
     - pos: 11.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4796
     components:
     - pos: 10.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4797
     components:
     - pos: 9.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4798
     components:
     - pos: 8.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4799
     components:
     - pos: 7.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4800
     components:
     - pos: 6.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4801
     components:
     - pos: 5.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4802
     components:
     - pos: 4.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4803
     components:
     - pos: 3.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4804
     components:
     - pos: 2.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4805
     components:
     - pos: 1.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4806
     components:
     - pos: 0.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4808
     components:
     - pos: -0.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4809
     components:
     - pos: -0.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4810
     components:
     - pos: -0.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4811
     components:
     - pos: -0.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4812
     components:
     - pos: -0.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4813
     components:
     - pos: -0.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4814
     components:
     - pos: 15.5,-17.5
@@ -16695,22 +13517,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4856
     components:
     - pos: 0.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4972
     components:
     - pos: 15.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4974
     components:
     - pos: 18.5,-17.5
@@ -16718,15 +13534,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4975
     components:
     - pos: 19.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5071
     components:
     - pos: 22.5,-17.5
@@ -16734,50 +13546,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5072
     components:
     - pos: 23.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5073
     components:
     - pos: 23.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5074
     components:
     - pos: 23.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5081
     components:
     - pos: 21.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5082
     components:
     - pos: 21.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5083
     components:
     - pos: 21.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5084
     components:
     - pos: 24.5,-16.5
@@ -16785,8 +13583,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5085
     components:
     - pos: 25.5,-16.5
@@ -16794,8 +13590,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5086
     components:
     - pos: 26.5,-16.5
@@ -16803,8 +13597,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5087
     components:
     - pos: 27.5,-16.5
@@ -16812,71 +13604,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5088
     components:
     - pos: 28.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5089
     components:
     - pos: 29.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5090
     components:
     - pos: 30.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5091
     components:
     - pos: 31.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5092
     components:
     - pos: 32.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5093
     components:
     - pos: 32.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5094
     components:
     - pos: 32.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5095
     components:
     - pos: 32.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5096
     components:
     - pos: 32.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5097
     components:
     - pos: 32.5,-21.5
@@ -16884,8 +13656,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5098
     components:
     - pos: 32.5,-22.5
@@ -16893,8 +13663,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5099
     components:
     - pos: 32.5,-23.5
@@ -16902,8 +13670,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5100
     components:
     - pos: 32.5,-24.5
@@ -16911,8 +13677,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5101
     components:
     - pos: 32.5,-25.5
@@ -16920,8 +13684,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5185
     components:
     - pos: 31.5,-25.5
@@ -16929,8 +13691,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5186
     components:
     - pos: 30.5,-25.5
@@ -16938,8 +13698,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5187
     components:
     - pos: 33.5,-25.5
@@ -16947,8 +13705,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5188
     components:
     - pos: 34.5,-25.5
@@ -16956,8 +13712,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5189
     components:
     - pos: 34.5,-23.5
@@ -16965,8 +13719,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5190
     components:
     - pos: 33.5,-23.5
@@ -16974,8 +13726,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5191
     components:
     - pos: 31.5,-23.5
@@ -16983,8 +13733,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5192
     components:
     - pos: 30.5,-23.5
@@ -16992,8 +13740,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5193
     components:
     - pos: 31.5,-21.5
@@ -17001,8 +13747,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5194
     components:
     - pos: 30.5,-21.5
@@ -17010,8 +13754,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5195
     components:
     - pos: 33.5,-21.5
@@ -17019,8 +13761,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5196
     components:
     - pos: 34.5,-21.5
@@ -17028,344 +13768,246 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5341
     components:
     - pos: 29.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5342
     components:
     - pos: 29.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5343
     components:
     - pos: 29.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5344
     components:
     - pos: 29.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5807
     components:
     - pos: -3.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5808
     components:
     - pos: 1.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5809
     components:
     - pos: 2.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5810
     components:
     - pos: 3.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5811
     components:
     - pos: 4.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5812
     components:
     - pos: -1.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5813
     components:
     - pos: -2.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6006
     components:
     - pos: 12.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6007
     components:
     - pos: 12.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6008
     components:
     - pos: 12.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6009
     components:
     - pos: 12.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6010
     components:
     - pos: 12.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6011
     components:
     - pos: 12.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6012
     components:
     - pos: 11.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6013
     components:
     - pos: 10.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6014
     components:
     - pos: 9.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6015
     components:
     - pos: 8.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6016
     components:
     - pos: 7.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6017
     components:
     - pos: 6.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6018
     components:
     - pos: 5.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6019
     components:
     - pos: -6.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6020
     components:
     - pos: -6.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6021
     components:
     - pos: -5.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6022
     components:
     - pos: -0.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6023
     components:
     - pos: 5.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6026
     components:
     - pos: 0.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6027
     components:
     - pos: -4.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6028
     components:
     - pos: -6.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6029
     components:
     - pos: -6.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6030
     components:
     - pos: -6.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6031
     components:
     - pos: -7.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6032
     components:
     - pos: -8.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6033
     components:
     - pos: -9.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6034
     components:
     - pos: -10.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6035
     components:
     - pos: -11.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6036
     components:
     - pos: -12.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6037
     components:
     - pos: -13.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6038
     components:
     - pos: -14.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6039
     components:
     - pos: -14.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6040
     components:
     - pos: -14.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6041
     components:
     - pos: -14.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6042
     components:
     - pos: -14.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6043
     components:
     - pos: -14.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6044
     components:
     - pos: -14.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6045
     components:
     - pos: -15.5,-25.5
@@ -17373,15 +14015,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6046
     components:
     - pos: -16.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6047
     components:
     - pos: -17.5,-25.5
@@ -17389,43 +14027,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6048
     components:
     - pos: -18.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6049
     components:
     - pos: -18.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6050
     components:
     - pos: -18.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6051
     components:
     - pos: -18.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6052
     components:
     - pos: -18.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6053
     components:
     - pos: -17.5,-29.5
@@ -17433,8 +14059,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6054
     components:
     - pos: -16.5,-29.5
@@ -17442,36 +14066,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6166
     components:
     - pos: -6.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6167
     components:
     - pos: -5.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6168
     components:
     - pos: -4.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6169
     components:
     - pos: -3.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6170
     components:
     - pos: -2.5,-32.5
@@ -17479,8 +14093,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6171
     components:
     - pos: -2.5,-33.5
@@ -17488,8 +14100,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6172
     components:
     - pos: -2.5,-31.5
@@ -17497,36 +14107,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6173
     components:
     - pos: 5.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6174
     components:
     - pos: 4.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6175
     components:
     - pos: 3.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6176
     components:
     - pos: 2.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6177
     components:
     - pos: 1.5,-32.5
@@ -17534,8 +14134,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6178
     components:
     - pos: 1.5,-33.5
@@ -17543,8 +14141,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6179
     components:
     - pos: 1.5,-31.5
@@ -17552,85 +14148,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6253
     components:
     - pos: -3.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6254
     components:
     - pos: -3.5,-34.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6255
     components:
     - pos: -3.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6256
     components:
     - pos: -2.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6257
     components:
     - pos: -1.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6258
     components:
     - pos: -0.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6259
     components:
     - pos: 0.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6260
     components:
     - pos: 1.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6261
     components:
     - pos: 2.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6262
     components:
     - pos: 2.5,-34.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6263
     components:
     - pos: 2.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6264
     components:
     - pos: -0.5,-34.5
@@ -17638,8 +14210,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6265
     components:
     - pos: 0.5,-34.5
@@ -17647,8 +14217,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6266
     components:
     - pos: -1.5,-34.5
@@ -17656,15 +14224,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6616
     components:
     - pos: 29.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
 - proto: CableMV
   entities:
   - uid: 1146
@@ -17674,8 +14238,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1147
     components:
     - pos: 16.5,-13.5
@@ -17683,64 +14245,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1148
     components:
     - pos: 17.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1149
     components:
     - pos: 17.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1150
     components:
     - pos: 17.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1151
     components:
     - pos: 18.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1153
     components:
     - pos: 19.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1154
     components:
     - pos: 21.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1155
     components:
     - pos: 22.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1156
     components:
     - pos: 23.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1157
     components:
     - pos: 23.5,-10.5
@@ -17748,64 +14292,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1158
     components:
     - pos: 17.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1159
     components:
     - pos: 17.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1160
     components:
     - pos: 17.5,-8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1161
     components:
     - pos: 17.5,-7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1162
     components:
     - pos: 17.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1163
     components:
     - pos: 18.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1164
     components:
     - pos: 19.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1165
     components:
     - pos: 20.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1166
     components:
     - pos: 20.5,-7.5
@@ -17813,71 +14339,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1167
     components:
     - pos: 16.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1168
     components:
     - pos: 15.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1169
     components:
     - pos: 13.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1170
     components:
     - pos: 14.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1171
     components:
     - pos: 12.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1172
     components:
     - pos: 11.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1173
     components:
     - pos: 10.5,-6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1174
     components:
     - pos: 10.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1175
     components:
     - pos: 10.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1176
     components:
     - pos: 10.5,-3.5
@@ -17885,57 +14391,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1182
     components:
     - pos: 19.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1321
     components:
     - pos: -3.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1323
     components:
     - pos: 16.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1324
     components:
     - pos: 15.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1325
     components:
     - pos: 14.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1326
     components:
     - pos: 13.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1327
     components:
     - pos: 12.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1328
     components:
     - pos: 12.5,-10.5
@@ -17943,85 +14433,61 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1329
     components:
     - pos: 11.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1330
     components:
     - pos: 10.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1331
     components:
     - pos: 9.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1332
     components:
     - pos: 8.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1333
     components:
     - pos: 7.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1334
     components:
     - pos: 6.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1335
     components:
     - pos: 5.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1336
     components:
     - pos: 4.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1337
     components:
     - pos: 3.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1338
     components:
     - pos: 3.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1339
     components:
     - pos: 3.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1340
     components:
     - pos: 3.5,-8.5
@@ -18029,8 +14495,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1805
     components:
     - pos: -3.5,20.5
@@ -18038,43 +14502,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1806
     components:
     - pos: -3.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1807
     components:
     - pos: -4.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1808
     components:
     - pos: -5.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1809
     components:
     - pos: -5.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1810
     components:
     - pos: -5.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1811
     components:
     - pos: -4.5,19.5
@@ -18082,36 +14534,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1812
     components:
     - pos: -6.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1813
     components:
     - pos: -6.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1814
     components:
     - pos: -6.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1815
     components:
     - pos: -5.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1816
     components:
     - pos: -4.5,17.5
@@ -18119,57 +14561,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1817
     components:
     - pos: -6.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1818
     components:
     - pos: -6.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1819
     components:
     - pos: -6.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1820
     components:
     - pos: -6.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1821
     components:
     - pos: -6.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1822
     components:
     - pos: -7.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1823
     components:
     - pos: -8.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1824
     components:
     - pos: -8.5,13.5
@@ -18177,22 +14603,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1825
     components:
     - pos: -5.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1826
     components:
     - pos: -5.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1827
     components:
     - pos: -4.5,11.5
@@ -18200,78 +14620,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1828
     components:
     - pos: -7.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1829
     components:
     - pos: -8.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1830
     components:
     - pos: -9.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1831
     components:
     - pos: -10.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1832
     components:
     - pos: -10.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1833
     components:
     - pos: -10.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1834
     components:
     - pos: -11.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1835
     components:
     - pos: -12.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1836
     components:
     - pos: -13.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1837
     components:
     - pos: -14.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1838
     components:
     - pos: -14.5,18.5
@@ -18279,8 +14677,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1839
     components:
     - pos: 2.5,20.5
@@ -18288,8 +14684,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1840
     components:
     - pos: 1.5,20.5
@@ -18297,8 +14691,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1841
     components:
     - pos: 0.5,20.5
@@ -18306,8 +14698,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1842
     components:
     - pos: -0.5,20.5
@@ -18315,8 +14705,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1843
     components:
     - pos: -0.5,19.5
@@ -18324,8 +14712,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1844
     components:
     - pos: -0.5,18.5
@@ -18333,8 +14719,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1845
     components:
     - pos: -0.5,17.5
@@ -18342,120 +14726,86 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 1846
     components:
     - pos: -0.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1847
     components:
     - pos: -0.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1848
     components:
     - pos: -0.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1849
     components:
     - pos: -0.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1850
     components:
     - pos: -0.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1851
     components:
     - pos: -0.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1852
     components:
     - pos: -0.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1853
     components:
     - pos: -0.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1854
     components:
     - pos: -0.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1855
     components:
     - pos: -0.5,7.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1856
     components:
     - pos: -0.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1857
     components:
     - pos: -0.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1858
     components:
     - pos: -0.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1859
     components:
     - pos: -1.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1860
     components:
     - pos: -2.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1862
     components:
     - pos: -2.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 1863
     components:
     - pos: -2.5,2.5
@@ -18463,22 +14813,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2014
     components:
     - pos: 0.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2015
     components:
     - pos: 1.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2016
     components:
     - pos: 1.5,17.5
@@ -18486,22 +14830,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2017
     components:
     - pos: -0.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2018
     components:
     - pos: -1.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2019
     components:
     - pos: -1.5,22.5
@@ -18509,8 +14847,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2056
     components:
     - pos: -3.5,5.5
@@ -18518,8 +14854,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2947
     components:
     - pos: 15.5,19.5
@@ -18527,8 +14861,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2948
     components:
     - pos: 15.5,18.5
@@ -18536,8 +14868,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2949
     components:
     - pos: 14.5,18.5
@@ -18545,8 +14875,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2950
     components:
     - pos: 14.5,17.5
@@ -18554,8 +14882,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2951
     components:
     - pos: 14.5,16.5
@@ -18563,71 +14889,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2952
     components:
     - pos: 14.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2953
     components:
     - pos: 14.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2954
     components:
     - pos: 14.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2955
     components:
     - pos: 15.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2956
     components:
     - pos: 16.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2957
     components:
     - pos: 17.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2958
     components:
     - pos: 17.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2959
     components:
     - pos: 17.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2960
     components:
     - pos: 17.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2961
     components:
     - pos: 17.5,17.5
@@ -18635,71 +14941,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2962
     components:
     - pos: 17.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2963
     components:
     - pos: 18.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2964
     components:
     - pos: 19.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2965
     components:
     - pos: 20.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2966
     components:
     - pos: 21.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2967
     components:
     - pos: 22.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2968
     components:
     - pos: 23.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2969
     components:
     - pos: 24.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2970
     components:
     - pos: 24.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2971
     components:
     - pos: 24.5,14.5
@@ -18707,78 +14993,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2972
     components:
     - pos: 19.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2973
     components:
     - pos: 19.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2974
     components:
     - pos: 19.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2975
     components:
     - pos: 19.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2976
     components:
     - pos: 19.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2977
     components:
     - pos: 19.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2978
     components:
     - pos: 19.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2979
     components:
     - pos: 19.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2980
     components:
     - pos: 19.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2981
     components:
     - pos: 20.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2982
     components:
     - pos: 21.5,21.5
@@ -18786,127 +15050,91 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 2983
     components:
     - pos: 25.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2984
     components:
     - pos: 26.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2985
     components:
     - pos: 27.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2986
     components:
     - pos: 28.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2987
     components:
     - pos: 29.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2988
     components:
     - pos: 30.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2989
     components:
     - pos: 31.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2990
     components:
     - pos: 32.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2991
     components:
     - pos: 33.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2992
     components:
     - pos: 34.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2993
     components:
     - pos: 34.5,13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2994
     components:
     - pos: 34.5,14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2995
     components:
     - pos: 34.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2996
     components:
     - pos: 34.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2997
     components:
     - pos: 34.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2998
     components:
     - pos: 34.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 2999
     components:
     - pos: 34.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3000
     components:
     - pos: 35.5,19.5
@@ -18914,57 +15142,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3001
     components:
     - pos: 13.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3002
     components:
     - pos: 12.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3003
     components:
     - pos: 11.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3004
     components:
     - pos: 10.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3005
     components:
     - pos: 9.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3006
     components:
     - pos: 8.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3007
     components:
     - pos: 7.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3008
     components:
     - pos: 7.5,16.5
@@ -18972,92 +15184,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3009
     components:
     - pos: 11.5,16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3010
     components:
     - pos: 11.5,17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3011
     components:
     - pos: 11.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3012
     components:
     - pos: 11.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3013
     components:
     - pos: 11.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3014
     components:
     - pos: 11.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3015
     components:
     - pos: 10.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3016
     components:
     - pos: 9.5,21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3017
     components:
     - pos: 9.5,20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3018
     components:
     - pos: 9.5,19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3019
     components:
     - pos: 9.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3020
     components:
     - pos: 8.5,18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3021
     components:
     - pos: 7.5,18.5
@@ -19065,36 +15251,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3022
     components:
     - pos: 9.5,22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3023
     components:
     - pos: 9.5,23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3024
     components:
     - pos: 9.5,24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3025
     components:
     - pos: 9.5,25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3026
     components:
     - pos: 9.5,26.5
@@ -19102,43 +15278,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3027
     components:
     - pos: 9.5,27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3028
     components:
     - pos: 9.5,28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3029
     components:
     - pos: 9.5,29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3030
     components:
     - pos: 9.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3031
     components:
     - pos: 8.5,30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3032
     components:
     - pos: 7.5,30.5
@@ -19146,22 +15310,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3575
     components:
     - pos: -15.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3576
     components:
     - pos: -15.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3578
     components:
     - pos: -14.5,6.5
@@ -19169,8 +15327,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3579
     components:
     - pos: -13.5,6.5
@@ -19178,64 +15334,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3580
     components:
     - pos: -16.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3581
     components:
     - pos: -17.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3582
     components:
     - pos: -18.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3583
     components:
     - pos: -19.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3584
     components:
     - pos: -20.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3585
     components:
     - pos: -21.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3586
     components:
     - pos: -22.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3587
     components:
     - pos: -22.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3588
     components:
     - pos: -22.5,7.5
@@ -19243,43 +15381,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3589
     components:
     - pos: -22.5,8.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3590
     components:
     - pos: -22.5,9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3591
     components:
     - pos: -22.5,10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3592
     components:
     - pos: -22.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3593
     components:
     - pos: -22.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3594
     components:
     - pos: -22.5,13.5
@@ -19287,57 +15413,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 3595
     components:
     - pos: -21.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3596
     components:
     - pos: -20.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3597
     components:
     - pos: -19.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3598
     components:
     - pos: -18.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3599
     components:
     - pos: -17.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3600
     components:
     - pos: -16.5,11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3601
     components:
     - pos: -16.5,12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 3602
     components:
     - pos: -16.5,13.5
@@ -19345,8 +15455,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4105
     components:
     - pos: -31.5,2.5
@@ -19354,57 +15462,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4106
     components:
     - pos: -31.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4107
     components:
     - pos: -31.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4108
     components:
     - pos: -31.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4109
     components:
     - pos: -31.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4110
     components:
     - pos: -30.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4111
     components:
     - pos: -29.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4112
     components:
     - pos: -28.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4113
     components:
     - pos: -27.5,4.5
@@ -19412,8 +15504,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4114
     components:
     - pos: -27.5,5.5
@@ -19421,15 +15511,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4115
     components:
     - pos: -27.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4116
     components:
     - pos: -31.5,7.5
@@ -19437,43 +15523,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4117
     components:
     - pos: -31.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4118
     components:
     - pos: -31.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4119
     components:
     - pos: -31.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4120
     components:
     - pos: -30.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4121
     components:
     - pos: -29.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4122
     components:
     - pos: -28.5,-0.5
@@ -19481,15 +15555,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4123
     components:
     - pos: -27.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4124
     components:
     - pos: -26.5,-0.5
@@ -19497,50 +15567,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4125
     components:
     - pos: -25.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4126
     components:
     - pos: -24.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4127
     components:
     - pos: -23.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4128
     components:
     - pos: -22.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4129
     components:
     - pos: -21.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4130
     components:
     - pos: -21.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4131
     components:
     - pos: -21.5,-2.5
@@ -19548,43 +15604,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4132
     components:
     - pos: -20.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4133
     components:
     - pos: -19.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4134
     components:
     - pos: -18.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4135
     components:
     - pos: -17.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4136
     components:
     - pos: -17.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4137
     components:
     - pos: -17.5,1.5
@@ -19592,43 +15636,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4138
     components:
     - pos: -16.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4139
     components:
     - pos: -15.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4140
     components:
     - pos: -14.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4141
     components:
     - pos: -13.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4142
     components:
     - pos: -13.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4143
     components:
     - pos: -13.5,-2.5
@@ -19636,15 +15668,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4807
     components:
     - pos: 0.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4817
     components:
     - pos: 15.5,-17.5
@@ -19652,15 +15680,11 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4818
     components:
     - pos: 15.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4819
     components:
     - pos: 16.5,-18.5
@@ -19668,29 +15692,21 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4820
     components:
     - pos: 16.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4821
     components:
     - pos: 16.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4822
     components:
     - pos: 16.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4823
     components:
     - pos: 16.5,-22.5
@@ -19698,92 +15714,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4824
     components:
     - pos: 16.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4825
     components:
     - pos: 15.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4826
     components:
     - pos: 14.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4827
     components:
     - pos: 13.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4828
     components:
     - pos: 13.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4829
     components:
     - pos: 12.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4830
     components:
     - pos: 11.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4831
     components:
     - pos: 10.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4832
     components:
     - pos: 9.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4833
     components:
     - pos: 8.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4834
     components:
     - pos: 8.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4835
     components:
     - pos: 8.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4836
     components:
     - pos: 7.5,-24.5
@@ -19791,64 +15781,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4837
     components:
     - pos: 12.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4838
     components:
     - pos: 12.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4839
     components:
     - pos: 12.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4840
     components:
     - pos: 11.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4841
     components:
     - pos: 10.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4842
     components:
     - pos: 9.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4843
     components:
     - pos: 8.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4844
     components:
     - pos: 8.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4845
     components:
     - pos: 8.5,-17.5
@@ -19856,64 +15828,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4846
     components:
     - pos: 7.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4847
     components:
     - pos: 6.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4848
     components:
     - pos: 5.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4849
     components:
     - pos: 4.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4850
     components:
     - pos: 3.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4851
     components:
     - pos: 2.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4852
     components:
     - pos: 1.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4853
     components:
     - pos: 1.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4854
     components:
     - pos: 1.5,-20.5
@@ -19921,92 +15875,66 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4855
     components:
     - pos: 0.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4857
     components:
     - pos: -0.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4858
     components:
     - pos: -0.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4859
     components:
     - pos: -0.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4860
     components:
     - pos: -0.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4861
     components:
     - pos: -0.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4862
     components:
     - pos: -0.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4863
     components:
     - pos: -0.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4864
     components:
     - pos: -0.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4865
     components:
     - pos: -0.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4866
     components:
     - pos: -1.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4867
     components:
     - pos: -2.5,-9.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4868
     components:
     - pos: -3.5,-9.5
@@ -20014,71 +15942,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4869
     components:
     - pos: -0.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4870
     components:
     - pos: -0.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4871
     components:
     - pos: -0.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4872
     components:
     - pos: -0.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4873
     components:
     - pos: -0.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4874
     components:
     - pos: -0.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4875
     components:
     - pos: -0.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4876
     components:
     - pos: -1.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4877
     components:
     - pos: -2.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4878
     components:
     - pos: -2.5,-24.5
@@ -20086,64 +15994,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4879
     components:
     - pos: -3.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4880
     components:
     - pos: -4.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4881
     components:
     - pos: -5.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4882
     components:
     - pos: -6.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4883
     components:
     - pos: -7.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4884
     components:
     - pos: -8.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4885
     components:
     - pos: -9.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4886
     components:
     - pos: -9.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4887
     components:
     - pos: -8.5,-24.5
@@ -20151,71 +16041,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4888
     components:
     - pos: -1.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4889
     components:
     - pos: -2.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4890
     components:
     - pos: -3.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4891
     components:
     - pos: -4.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4892
     components:
     - pos: -5.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4893
     components:
     - pos: -6.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4894
     components:
     - pos: -7.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4895
     components:
     - pos: -8.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4896
     components:
     - pos: -9.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4897
     components:
     - pos: -9.5,-17.5
@@ -20223,22 +16093,16 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4966
     components:
     - pos: -1.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4967
     components:
     - pos: -1.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4976
     components:
     - pos: 17.5,-17.5
@@ -20246,8 +16110,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4978
     components:
     - pos: 18.5,-17.5
@@ -20255,50 +16117,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4979
     components:
     - pos: 19.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4980
     components:
     - pos: 20.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4981
     components:
     - pos: 20.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4982
     components:
     - pos: 20.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4983
     components:
     - pos: 20.5,-14.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4984
     components:
     - pos: 20.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4985
     components:
     - pos: 20.5,-12.5
@@ -20306,43 +16154,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 4986
     components:
     - pos: 20.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4987
     components:
     - pos: 21.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4988
     components:
     - pos: 20.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4989
     components:
     - pos: 20.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4990
     components:
     - pos: 19.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 4991
     components:
     - pos: 18.5,-19.5
@@ -20350,71 +16186,51 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5277
     components:
     - pos: 21.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5278
     components:
     - pos: 22.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5279
     components:
     - pos: 23.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5280
     components:
     - pos: 24.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5281
     components:
     - pos: 25.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5282
     components:
     - pos: 26.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5283
     components:
     - pos: 27.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5284
     components:
     - pos: 28.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5285
     components:
     - pos: 29.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5286
     components:
     - pos: 29.5,-19.5
@@ -20422,36 +16238,26 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5287
     components:
     - pos: 30.5,-18.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5288
     components:
     - pos: 30.5,-17.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5289
     components:
     - pos: 30.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5290
     components:
     - pos: 30.5,-15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5291
     components:
     - pos: 30.5,-14.5
@@ -20459,64 +16265,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5292
     components:
     - pos: 30.5,-13.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5293
     components:
     - pos: 30.5,-12.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5294
     components:
     - pos: 30.5,-11.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5295
     components:
     - pos: 30.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5296
     components:
     - pos: 31.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5297
     components:
     - pos: 32.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5298
     components:
     - pos: 33.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5299
     components:
     - pos: 34.5,-10.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5300
     components:
     - pos: 34.5,-9.5
@@ -20524,8 +16312,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5301
     components:
     - pos: 22.5,-23.5
@@ -20533,50 +16319,36 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5302
     components:
     - pos: 23.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5303
     components:
     - pos: 24.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5304
     components:
     - pos: 24.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5305
     components:
     - pos: 24.5,-21.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5306
     components:
     - pos: 24.5,-20.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5307
     components:
     - pos: 24.5,-19.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5424
     components:
     - pos: 16.5,-28.5
@@ -20584,99 +16356,71 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5425
     components:
     - pos: 16.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5426
     components:
     - pos: 16.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5427
     components:
     - pos: 16.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5428
     components:
     - pos: 17.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5429
     components:
     - pos: 18.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5430
     components:
     - pos: 19.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5431
     components:
     - pos: 20.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5432
     components:
     - pos: 21.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5433
     components:
     - pos: 22.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5434
     components:
     - pos: 23.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5435
     components:
     - pos: 24.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5436
     components:
     - pos: 24.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5437
     components:
     - pos: 20.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5438
     components:
     - pos: 20.5,-23.5
@@ -20684,8 +16428,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5439
     components:
     - pos: 21.5,-23.5
@@ -20693,8 +16435,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5440
     components:
     - pos: 19.5,-23.5
@@ -20702,43 +16442,31 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5832
     components:
     - pos: 10.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5833
     components:
     - pos: 9.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5834
     components:
     - pos: 9.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5835
     components:
     - pos: 9.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5836
     components:
     - pos: 9.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5837
     components:
     - pos: 9.5,2.5
@@ -20746,64 +16474,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5838
     components:
     - pos: 9.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5839
     components:
     - pos: 10.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5840
     components:
     - pos: 10.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5841
     components:
     - pos: 10.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5842
     components:
     - pos: 10.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5843
     components:
     - pos: 10.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5844
     components:
     - pos: 11.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5845
     components:
     - pos: 12.5,6.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5846
     components:
     - pos: 12.5,7.5
@@ -20811,8 +16521,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5854
     components:
     - pos: 20.5,6.5
@@ -20820,148 +16528,106 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 5855
     components:
     - pos: 20.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5856
     components:
     - pos: 19.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5857
     components:
     - pos: 18.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5858
     components:
     - pos: 17.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5859
     components:
     - pos: 16.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5860
     components:
     - pos: 15.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5861
     components:
     - pos: 14.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5862
     components:
     - pos: 13.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5863
     components:
     - pos: 12.5,5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5865
     components:
     - pos: 20.5,4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5866
     components:
     - pos: 20.5,3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5867
     components:
     - pos: 20.5,2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5868
     components:
     - pos: 20.5,1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5869
     components:
     - pos: 20.5,0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5870
     components:
     - pos: 20.5,-0.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5871
     components:
     - pos: 20.5,-1.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5872
     components:
     - pos: 20.5,-2.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5873
     components:
     - pos: 20.5,-3.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5874
     components:
     - pos: 20.5,-4.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 5875
     components:
     - pos: 20.5,-5.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6055
     components:
     - pos: -16.5,-29.5
@@ -20969,8 +16635,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6056
     components:
     - pos: -16.5,-30.5
@@ -20978,8 +16642,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6057
     components:
     - pos: -17.5,-29.5
@@ -20987,64 +16649,46 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6058
     components:
     - pos: -18.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6059
     components:
     - pos: -18.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6060
     components:
     - pos: -18.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6061
     components:
     - pos: -18.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6062
     components:
     - pos: -18.5,-25.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6063
     components:
     - pos: -18.5,-24.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6064
     components:
     - pos: -18.5,-23.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6065
     components:
     - pos: -18.5,-22.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6066
     components:
     - pos: -17.5,-22.5
@@ -21052,57 +16696,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6104
     components:
     - pos: -17.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6105
     components:
     - pos: -16.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6106
     components:
     - pos: -15.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6107
     components:
     - pos: -14.5,-26.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6108
     components:
     - pos: -14.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6109
     components:
     - pos: -14.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6110
     components:
     - pos: -14.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6111
     components:
     - pos: -15.5,-28.5
@@ -21110,57 +16738,41 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6182
     components:
     - pos: -14.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6183
     components:
     - pos: -14.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6184
     components:
     - pos: -13.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6185
     components:
     - pos: -12.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6186
     components:
     - pos: -11.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6187
     components:
     - pos: -10.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6188
     components:
     - pos: -9.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6189
     components:
     - pos: -8.5,-30.5
@@ -21168,8 +16780,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6190
     components:
     - pos: 7.5,-30.5
@@ -21177,148 +16787,106 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6191
     components:
     - pos: 8.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6192
     components:
     - pos: 9.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6193
     components:
     - pos: 10.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6194
     components:
     - pos: 11.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6195
     components:
     - pos: 12.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6196
     components:
     - pos: 13.5,-30.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6197
     components:
     - pos: 13.5,-29.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6198
     components:
     - pos: 13.5,-28.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6199
     components:
     - pos: 13.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6200
     components:
     - pos: 14.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6201
     components:
     - pos: 15.5,-27.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6336
     components:
     - pos: -8.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6337
     components:
     - pos: -7.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6338
     components:
     - pos: -6.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6339
     components:
     - pos: -5.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6340
     components:
     - pos: -4.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6341
     components:
     - pos: -3.5,-31.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6342
     components:
     - pos: -3.5,-32.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6343
     components:
     - pos: -3.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6344
     components:
     - pos: -3.5,-34.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6345
     components:
     - pos: -2.5,-34.5
@@ -21326,78 +16894,56 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
   - uid: 6398
     components:
     - pos: -2.5,-35.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6399
     components:
     - pos: -2.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6400
     components:
     - pos: -2.5,-36.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6401
     components:
     - pos: -1.5,-37.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6402
     components:
     - pos: -2.5,-37.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6403
     components:
     - pos: -1.5,-38.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6404
     components:
     - pos: -1.5,-39.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6405
     components:
     - pos: -1.5,-40.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6406
     components:
     - pos: -1.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6407
     components:
     - pos: -2.5,-41.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6408
     components:
     - pos: -2.5,-40.5
@@ -21405,8 +16951,6 @@ entities:
       type: Transform
     - enabled: True
       type: AmbientSound
-    - fixtures: {}
-      type: Fixtures
 - proto: CableTerminal
   entities:
   - uid: 5075
@@ -26388,22 +21932,16 @@ entities:
     - pos: -20.5,15.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6622
     components:
     - pos: 12.5,-16.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
   - uid: 6623
     components:
     - pos: -16.5,-33.5
       parent: 1668
       type: Transform
-    - fixtures: {}
-      type: Fixtures
 - proto: FoodBoxDonkpocketPizza
   entities:
   - uid: 2227


### PR DESCRIPTION
## About the PR
Allows the CentComm map to spawn again, so the evac shuttle actually goes somewhere