### PR TITLE
Enable loneops

### DIFF
--- a/Resources/Changelog/DeltaVChangelog.yml
+++ b/Resources/Changelog/DeltaVChangelog.yml
@@ -61,3 +61,9 @@ Entries:
         type: Fix
     id: 10
     time: '2023-05-18T00:00:00.0000000+00:00'
+  - author: Scribbles0
+    changes:
+      - message: Lone nuclear operatives have recently started attacking stations. Make sure to watch out for them on long, extended shifts.
+        type: add
+    id: 11
+    time: '2023-05-23T00:00:00.0000000+00:00'

--- a/Resources/Prototypes/GameRules/events.yml
+++ b/Resources/Prototypes/GameRules/events.yml
@@ -329,15 +329,15 @@
 #     duration: 1
 #   - type: ZombieRule
 
-# - type: entity
-#   id: LoneOpsSpawn
-#   parent: BaseGameRule
-#   noSpawn: true
-#   components:
-#   - type: StationEvent
-#     earliestStart: 55
-#     weight: 5
-#     minimumPlayers: 10
-#     reoccurrenceDelay: 25
-#     duration: 1
-#   - type: LoneOpsSpawnRule
+- type: entity
+  id: LoneOpsSpawn
+  parent: BaseGameRule
+  noSpawn: true
+  components:
+  - type: StationEvent
+    earliestStart: 90
+    weight: 5
+    minimumPlayers: 10
+    reoccurrenceDelay: 25
+    duration: 1
+  - type: LoneOpsSpawnRule


### PR DESCRIPTION
## About the PR
This enables the loneops gamerule, and sets the time it can start at at 90 minutes into a round. What could possibly go wrong?