### PR TITLE
Nerf assault robots

### DIFF
--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -5,7 +5,7 @@
   productEntity: CyborgBeaconSyndicate
   icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
   cost:
-    Telecrystal: 40
+    Telecrystal: 65
   categories:
     - UplinkUtility
   conditions:

--- a/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/uplink_catalog.yml
@@ -1,19 +1,19 @@
-﻿- type: listing
-  id: UplinkCyborgBeaconSyndicate
-  name: uplink-borg-beacon-name
-  description: uplink-borg-beacon-desc
-  productEntity: CyborgBeaconSyndicate
-  icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
-  cost:
-    Telecrystal: 65
-  categories:
-    - UplinkUtility
-  conditions:
-    - !type:StoreWhitelistCondition
-      whitelist:
-        tags:
-          - NukeOpsUplink
-    - !type:BuyerWhitelistCondition
-      blacklist:
-        components:
-          - SurplusBundle
+﻿#- type: listing
+#  id: UplinkCyborgBeaconSyndicate
+#  name: uplink-borg-beacon-name
+#  description: uplink-borg-beacon-desc
+#  productEntity: CyborgBeaconSyndicate
+#  icon: { sprite: Objects/Devices/communication.rsi, state: old-radio }
+#  cost:
+#    Telecrystal: 65
+#  categories:
+#    - UplinkUtility
+#  conditions:
+#    - !type:StoreWhitelistCondition
+#      whitelist:
+#        tags:
+#          - NukeOpsUplink
+#    - !type:BuyerWhitelistCondition
+#      blacklist:
+#        components:
+#          - SurplusBundle

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/replicated.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Ammunition/Projectiles/replicated.yml
@@ -8,4 +8,4 @@
       damage:
         types:
           Piercing: 5
-          Blunt: 10
+          Blunt: 7

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/LMGs/lmgs.yml
@@ -17,7 +17,7 @@
       maxAngle: 20
       angleIncrease: 4
       angleDecay: 16
-      fireRate: 8
+      fireRate: 5
       selectedMode: FullAuto
       availableModes:
         - FullAuto
@@ -26,7 +26,7 @@
       soundEmpty:
         path: /Audio/Weapons/Guns/Empty/lmg_empty.ogg
     - type: Battery
-      maxCharge: 1000
+      maxCharge: 800
       startingCharge: 500
     - type: ProjectileBatteryAmmoProvider
       proto: CartridgeLightRifleReplicated

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Launchers/launchers.yml
@@ -20,11 +20,11 @@
       soundGunshot:
         path: /Audio/Weapons/Guns/Gunshots/grenade_launcher.ogg
     - type: Battery
-      maxCharge: 999
-      startingCharge: 333
+      maxCharge: 600
+      startingCharge: 300
     - type: ProjectileBatteryAmmoProvider
       proto: GrenadeFrag
-      fireCost: 333
+      fireCost: 300
     - type: BatterySelfRecharger
       autoRecharge: true
-      autoRechargeRate: 5
+      autoRechargeRate: 2


### PR DESCRIPTION
Heavily reduces their fire rate and damage output, along with making ammo recharging slower and decreasing the amount of stored ammo.

Also fully disabled them in the uplink so admins can control when they happen and make it easier to decide on further nerfs