### PR TITLE
Update security_cadet.yml

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
+++ b/Resources/Prototypes/Roles/Jobs/Security/security_cadet.yml
@@ -17,6 +17,7 @@
   whitelistRequired: true
   access:
   - Security
+  - Brig
   - Maintenance
 
 - type: startingGear


### PR DESCRIPTION
## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes an oversight that removed Brig access from Cadets.

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Security cadets regained their Brig access.
