### PR TITLE
Fix some morphotypes speed

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/diona.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/diona.yml
@@ -41,9 +41,6 @@
   - type: Inventory
     templateId: diona
   - type: InventorySlots
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 5
 
 - type: entity
   save: false

--- a/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/reptilian.yml
@@ -49,9 +49,6 @@
     heatDamage:
       types:
         Heat : 0.1 #per second, scales with temperature & other constants
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 5
   - type: Perishable
   - type: Carriable
 

--- a/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/vulpkanin.yml
@@ -25,9 +25,6 @@
       types:
         Blunt: 1
         Slash: 5
-  - type: MovementSpeedModifier
-    baseWalkSpeed : 3
-    baseSprintSpeed : 5
   - type: Perishable
   - type: Carriable
   - type: TemperatureProtection


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
Removes the MovementSpeedModifier component for Diona, Reptilian and Vulpkanin as it was, supposedly, intended for them to have the same walk and sprint speed as other morphotypes according to #16 

They now use the default values which are used by every other morphotypes, meaning they are no longer slightly faster.

tldr; changes 3 walkspeed and 5 sprintspeed to 2.5 walkspeed and 4.5 sprintspeed since that's the default.

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed some morphotypes accidentally being faster than others.
