### PR TITLE
Nerf maxcaps to sane levels

### DIFF
--- a/Content.Server/Atmos/Components/GasTankComponent.cs
+++ b/Content.Server/Atmos/Components/GasTankComponent.cs
@@ -7,7 +7,7 @@ namespace Content.Server.Atmos.Components
     [RegisterComponent]
     public sealed class GasTankComponent : Component, IGasMixtureHolder
     {
-        public const float MaxExplosionRange = 80f;
+        public const float MaxExplosionRange = 27.5f;
         private const float DefaultLowPressure = 0f;
         private const float DefaultOutputPressure = Atmospherics.OneAtmosphere;
 


### PR DESCRIPTION
## About the PR
This PR lowers the maximum radius for atmos tank explosions to 27.5. Or rather, the "radius".
The explosion refactor makes it really hard to properly balance maxcaps as is, due to pressure wave reflection, but this will do the trick in space. This makes it so maxcaps can still be used as a weapon.

As an alternative left to discretion of the maintainers, the radius could be reduced to 25. At this point, it stops being a station killer and becomes a department killer.


**Media**
Radius 27.5
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/6a332219-35a7-4a5c-b761-7db4e5152b3d)
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/b6f1756e-375b-406b-b05b-8deedf5945f7)

Radius 25
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/0f5bb1dd-66a3-45ad-a8af-86b6029e0b9a)
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/5042545d-f57e-4a53-b8a2-628ad64e2ecf)
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/e97f4096-ab6c-43e3-84ce-484926e2aa41)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl: router
- tweak: Maxcaps have had their radius reduced by roughly 3x, from 80 to 27.5 due to a flimsier gas tank construction.
