### PR TITLE
Reverts Atmos Tech Syndie possibility

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -11,7 +11,7 @@
   icon: "AtmosphericTechnician"
   supervisors: job-supervisors-ce
   whitelistRequired: true
-  antagAdvantage: 10
+  canBeAntag: false
   access:
   - Maintenance
   - Engineering


### PR DESCRIPTION
**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- remove: Atmos no longer can be antagonists.
