### PR TITLE
Prevent non-admins from using fuckrules

### DIFF
--- a/Resources/clientCommandPerms.yml
+++ b/Resources/clientCommandPerms.yml
@@ -29,7 +29,6 @@
     - resetent
     - resetallents
     - cvar
-    - fuckrules
     - midipanic
     - redialrandom
     - replay_recording_start
@@ -72,6 +71,7 @@
     - detachent
     - localdelete
     - fullstatereset
+    - fuckrules
 
 - Flags: MAPPING
   Commands:


### PR DESCRIPTION
BP asked for it, so I deliver. `fuckrules` is now locked to the +DEBUG permission