### PR TITLE
Add the roundstart salvage shittle back

### DIFF
--- a/Resources/Maps/Shuttles/mining-deltav.yml
+++ b/Resources/Maps/Shuttles/mining-deltav.yml
@@ -1,0 +1,1432 @@
+meta:
+  format: 5
+  postmapinit: false
+tilemap:
+  0: Space
+  71: FloorSteel
+  81: FloorTechMaint
+  96: Lattice
+  97: Plating
+entities:
+- proto: ""
+  entities:
+  - uid: 100
+    components:
+    - type: MetaData
+    - type: Transform
+    - type: Map
+    - type: PhysicsMap
+    - type: GridTree
+    - type: MovedGrids
+    - type: Broadphase
+    - type: OccluderTree
+  - uid: 181
+    components:
+    - name: NT-Reclaimer
+      type: MetaData
+    - pos: 2.2710133,-2.4148211
+      parent: 100
+      type: Transform
+    - chunks:
+        -1,0:
+          ind: -1,0
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAFEAAABRAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAUQAAAEcAAANHAAADYQAAAFEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAFEAAABhAAAARwAAAUcAAABRAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAABhAAAAYQAAAEcAAAJhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABgAAAAYQAAAGEAAABHAAABRwAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABHAAABRwAAAUcAAAJhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAEcAAAFhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        0,-1:
+          ind: 0,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        0,0:
+          ind: 0,0
+          tiles: YQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==
+        -1,-1:
+          ind: -1,-1
+          tiles: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABhAAAAYQAAAGEAAABhAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGAAAABhAAAAYQAAAGEAAABhAAAAYQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAAYQAAAGEAAABhAAAAYQAAAGEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAEcAAAFHAAABRwAAAEcAAAJHAAADAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGEAAABHAAAARwAAAUcAAAJHAAACRwAAAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABhAAAARwAAAkcAAANHAAACRwAAA0cAAAIAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYQAAAEcAAANHAAACRwAAAEcAAANHAAACAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAYAAAAGEAAABHAAACRwAAAUcAAANHAAABRwAAAA==
+      type: MapGrid
+    - type: Broadphase
+    - bodyStatus: InAir
+      angularDamping: 0.05
+      linearDamping: 0.05
+      fixedRotation: False
+      bodyType: Dynamic
+      type: Physics
+    - fixtures: {}
+      type: Fixtures
+    - type: SalvageShuttle
+    - gravityShakeSound: !type:SoundPathSpecifier
+        path: /Audio/Effects/alert.ogg
+      type: Gravity
+    - chunkCollection:
+        version: 2
+        nodes:
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            6: -5,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            5: -3,1
+        - node:
+            angle: 1.5707963267948966 rad
+            color: '#FFFFFFFF'
+            id: Arrows
+          decals:
+            7: -1,-3
+        - node:
+            color: '#FFFFFFFF'
+            id: ArrowsGreyscale
+          decals:
+            203: -3,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: Bot
+          decals:
+            201: -5,-5
+            202: -1,-5
+        - node:
+            color: '#A4610696'
+            id: CheckerNWSE
+          decals:
+            16: -3,2
+            17: -3,3
+            18: -3,4
+        - node:
+            color: '#FFFFFFFF'
+            id: Delivery
+          decals:
+            4: -4,-1
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: Dirt
+          decals:
+            51: -3,-6
+            52: -4,-6
+            53: -2,1
+            54: -6,2
+            55: -6,1
+            56: -4,2
+            57: -5,2
+            58: -1,1
+            59: 0,2
+            60: -2,3
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtHeavy
+          decals:
+            21: -4,-3
+            22: -2,2
+            23: -3,4
+            24: -4,5
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtLight
+          decals:
+            30: -4,1
+            31: -3,2
+            32: -3,3
+            33: -2,4
+            34: -3,5
+            35: -2,-1
+            36: -3,-2
+            37: -2,-3
+            38: -3,-3
+            39: -3,-4
+            40: -2,-5
+            41: -1,-4
+            42: -1,-3
+            43: -3,-5
+            44: -4,-4
+            45: -5,-5
+            46: -5,-4
+            47: -5,-3
+            48: -5,-2
+            49: -4,-2
+            50: -1,-2
+        - node:
+            cleanable: True
+            color: '#FFFFFFFF'
+            id: DirtMedium
+          decals:
+            25: -2,-4
+            26: -4,-5
+            27: -2,-2
+            28: -3,-1
+            29: -3,1
+        - node:
+            color: '#A4610696'
+            id: QuarterTileOverlayGreyscale
+          decals:
+            10: -5,-2
+            11: -5,-1
+            20: -3,1
+        - node:
+            color: '#A4610696'
+            id: QuarterTileOverlayGreyscale180
+          decals:
+            14: -1,-5
+            15: -1,-4
+            19: -3,5
+        - node:
+            color: '#A4610696'
+            id: QuarterTileOverlayGreyscale270
+          decals:
+            8: -5,-5
+            9: -5,-4
+        - node:
+            color: '#A4610696'
+            id: QuarterTileOverlayGreyscale90
+          decals:
+            12: -1,-1
+            13: -1,-2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallGreyscaleSE
+          decals:
+            200: -5,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnCornerSmallGreyscaleSW
+          decals:
+            199: -1,-5
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndN
+          decals:
+            2: -6,2
+            3: 0,2
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnEndS
+          decals:
+            0: 0,1
+            1: -6,1
+        - node:
+            color: '#FFFFFFFF'
+            id: WarnLineGreyscaleS
+          decals:
+            196: -2,-5
+            197: -3,-5
+            198: -4,-5
+        - node:
+            angle: -4.71238898038469 rad
+            color: '#00000034'
+            id: footprint
+          decals:
+            138: -0.76830435,-4.312702
+            139: -1.1120543,-3.9220772
+            140: -1.2370543,-4.406452
+            141: -1.7526793,-4.109577
+            142: -1.7526793,-4.500202
+            143: -0.75267935,-2.5314522
+            144: -1.3308043,-2.1720772
+            145: -1.3933043,-2.6564522
+        - node:
+            cleanable: True
+            angle: -3.141592653589793 rad
+            color: '#00000034'
+            id: footprint
+          decals:
+            122: -2.8151793,1.7528267
+            123: -3.2995543,2.2528267
+            124: -2.8308043,2.3622017
+            125: -2.2995543,2.7372017
+            126: -2.3933043,1.1278267
+            127: -2.1276793,-1.5909233
+            128: -2.4089293,-1.9971733
+            129: -1.9245543,-2.6690483
+            130: -2.3620543,-3.0909233
+            131: -1.8776793,-3.6846733
+            132: -2.2683043,-4.0284233
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#00000034'
+            id: footprint
+          decals:
+            146: -1.2839293,-3.3127022
+            147: -0.94017935,-3.5627022
+            148: -5.2526793,-2.4064522
+            149: -4.8620543,-2.2814522
+            150: -4.2526793,-2.6720772
+            151: -4.0026793,-2.3595772
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#00000034'
+            id: footprint
+          decals:
+            133: -5.1901793,-3.6720772
+            134: -4.7683043,-3.3752022
+            135: -4.2683043,-3.7970772
+            136: -4.0026793,-3.5002022
+            137: -3.4089293,-3.8908272
+        - node:
+            angle: -1.5707963267948966 rad
+            color: '#0000004A'
+            id: footprint
+          decals:
+            152: -5.1901793,-3.430749
+            153: -4.8464293,-3.602624
+            154: -4.4245543,-3.258874
+            155: -3.9558043,-3.586999
+            156: -3.5808043,-3.180749
+            157: -5.3776793,-4.086999
+            158: -4.5808043,-3.711999
+        - node:
+            color: '#0000004A'
+            id: footprint
+          decals:
+            159: -2.6433043,-2.883874
+            160: -2.3776793,-2.508874
+            161: -2.8933043,-1.8994989
+            162: -2.3933043,-1.5869989
+            163: -2.7683043,-0.89949894
+            164: -2.2370543,-0.71199894
+        - node:
+            cleanable: True
+            angle: -4.71238898038469 rad
+            color: '#00000050'
+            id: footprint
+          decals:
+            76: 0.44651008,1.0549397
+            77: -0.13161492,0.82056475
+            78: -0.49098992,1.0393147
+            79: -1.2097399,0.99243975
+            80: -1.6472399,1.2893147
+            81: -1.8659899,0.96118975
+            82: -2.89724,1.1486897
+            83: -4.1628647,1.2111897
+            84: -4.5378647,1.4455647
+            85: -4.6003647,1.1643147
+            86: -5.3659897,1.5705647
+            87: -5.4128647,1.1330647
+            88: -6.0066147,1.5705647
+            89: -6.0066147,1.1643147
+            90: -6.5534897,1.4611897
+            91: -6.7253647,1.1330647
+        - node:
+            cleanable: True
+            angle: -1.5707963267948966 rad
+            color: '#00000050'
+            id: footprint
+          decals:
+            69: -1.8659899,1.6955647
+            70: -1.5847399,1.2893147
+            71: -0.9753649,1.5861897
+            72: -0.28786492,1.2893147
+            73: 0.08713508,1.6643147
+            74: 0.5402601,1.4455647
+            75: 0.6652601,1.8518147
+        - node:
+            cleanable: True
+            color: '#00000050'
+            id: footprint
+          decals:
+            61: -2.61599,-0.929533
+            62: -2.86599,-0.648283
+            63: -3.11599,2.4611897
+            64: -2.787865,3.2268147
+            65: -2.86599,2.8205647
+            66: -3.11599,3.0393147
+            67: -3.08474,3.5393147
+            68: -2.67849,4.1486897
+            116: -3.162865,1.6799397
+            117: -2.39724,2.1643147
+            118: -2.037865,2.3674397
+            119: -2.39724,2.9768147
+            120: -3.17849,3.8205647
+            121: -3.569115,2.5705647
+        - node:
+            cleanable: True
+            angle: 1.5707963267948966 rad
+            color: '#00000050'
+            id: footprint
+          decals:
+            110: -1.7566149,0.91431475
+            111: -2.225365,1.7580647
+            112: -1.8503649,2.0861897
+            113: -1.5222399,2.1330647
+            114: -1.0847399,1.3049397
+            115: -2.569115,1.6955647
+        - node:
+            cleanable: True
+            angle: 4.71238898038469 rad
+            color: '#00000050'
+            id: footprint
+          decals:
+            92: -6.7878647,2.0080647
+            93: -6.5222397,1.8049397
+            94: -6.0847397,2.0861897
+            95: -5.7722397,1.6643147
+            96: -5.4753647,2.0080647
+            97: -4.9909897,1.6799397
+            98: -4.5691147,2.0080647
+            99: -4.1941147,1.7424397
+            100: -3.86599,1.9455647
+            101: -6.5534897,0.69556475
+            102: -5.6003647,0.99243975
+            103: -5.1472397,0.72681475
+            104: -4.6784897,1.0705647
+            105: -4.4597397,0.89868975
+            106: -4.1941147,1.2268147
+            107: -3.70974,1.0080647
+            108: -3.975365,0.75806475
+            109: -3.694115,1.4143147
+        - node:
+            cleanable: True
+            color: '#0000001F'
+            id: splatter
+          decals:
+            165: -3.6745543,-4.4900737
+            166: -3.9714293,-4.5369487
+            167: -3.4714293,-5.0681987
+            168: -4.2370543,-4.9744487
+            169: -1.5495543,-1.4431987
+            170: -1.7058043,-1.2713237
+            171: -1.2058043,-1.3650737
+            172: -1.0339293,-1.9119487
+        - node:
+            cleanable: True
+            color: '#A461060F'
+            id: splatter
+          decals:
+            173: -1.4245543,-4.7713237
+            174: -1.7526793,-4.3650737
+            175: -4.0808043,-1.8806987
+            176: -4.3464293,-1.9119487
+            177: -3.5183043,-2.8338237
+            178: -4.8620543,-4.0994487
+            179: -4.4714293,-4.7869487
+            180: -3.9245543,-5.9275737
+            181: -3.4558043,-6.0838237
+            182: -2.6433043,1.3849263
+            183: -2.1589293,1.6661763
+            184: -2.4558043,1.8224263
+            185: -2.4089293,1.1193013
+        - node:
+            cleanable: True
+            color: '#D381C909'
+            id: splatter
+          decals:
+            186: -2.5808043,-4.6931987
+        - node:
+            cleanable: True
+            color: '#EFB34109'
+            id: splatter
+          decals:
+            187: -4.6901793,-1.6619487
+            188: -3.7370543,-1.4275737
+            189: -3.2995543,-1.4588237
+            190: -3.5651793,-0.8494487
+            191: -3.5339293,4.1436462
+            192: -3.3464293,3.6905212
+            193: -4.0495543,3.1123965
+            194: -3.9870543,3.6592712
+            195: -2.3151793,4.6123962
+      type: DecalGrid
+    - version: 2
+      data:
+        tiles:
+          -2,-1:
+            0: 52428
+            1: 8192
+          -1,-3:
+            0: 65504
+          -1,-1:
+            0: 65535
+          -1,-2:
+            0: 65535
+          -2,1:
+            0: 52428
+          -1,0:
+            0: 65535
+          -1,1:
+            0: 65535
+          -1,2:
+            0: 61183
+          -1,3:
+            0: 52974
+          0,-3:
+            0: 65520
+          0,-2:
+            0: 65535
+          0,-1:
+            0: 65535
+          1,-3:
+            0: 13072
+          1,-2:
+            0: 13107
+          1,-1:
+            0: 21811
+          0,1:
+            0: 65535
+          0,2:
+            0: 65535
+          0,3:
+            0: 65535
+          0,0:
+            0: 65535
+          1,3:
+            0: 273
+          1,0:
+            0: 30583
+          1,1:
+            0: 30039
+          1,2:
+            0: 4403
+          0,4:
+            0: 127
+          -1,4:
+            0: 140
+          -2,0:
+            0: 52428
+            1: 8738
+          -2,2:
+            0: 140
+          -2,-2:
+            0: 32768
+            1: 19656
+        uniqueMixes:
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 21.824879
+          - 82.10312
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        - volume: 2500
+          temperature: 293.15
+          moles:
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+          - 0
+        chunkSize: 4
+      type: GridAtmosphere
+    - type: OccluderTree
+    - type: Shuttle
+    - type: RadiationGridResistance
+    - type: SpreaderGrid
+    - type: GasTileOverlay
+    - type: GridPathfinding
+- proto: AirlockExternal
+  entities:
+  - uid: 4
+    components:
+    - pos: -6.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 14
+    components:
+    - pos: -6.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 29
+    components:
+    - pos: -4.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 30
+    components:
+    - pos: -4.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 34
+    components:
+    - pos: 1.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 36
+    components:
+    - pos: 1.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 49
+    components:
+    - pos: -0.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 54
+    components:
+    - pos: -0.5,1.5
+      parent: 181
+      type: Transform
+- proto: APCBasic
+  entities:
+  - uid: 7
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -0.5,-5.5
+      parent: 181
+      type: Transform
+  - uid: 68
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,3.5
+      parent: 181
+      type: Transform
+- proto: CableApcExtension
+  entities:
+  - uid: 1
+    components:
+    - pos: -3.5,-6.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 3
+    components:
+    - pos: -0.5,-4.5
+      parent: 181
+      type: Transform
+  - uid: 15
+    components:
+    - pos: -4.5,3.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 21
+    components:
+    - pos: -3.5,3.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 28
+    components:
+    - pos: -2.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 32
+    components:
+    - pos: -3.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 38
+    components:
+    - pos: -4.5,-1.5
+      parent: 181
+      type: Transform
+  - uid: 41
+    components:
+    - pos: -0.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 42
+    components:
+    - pos: -1.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 43
+    components:
+    - pos: -3.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 44
+    components:
+    - pos: -0.5,-1.5
+      parent: 181
+      type: Transform
+  - uid: 45
+    components:
+    - pos: -2.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 51
+    components:
+    - pos: -3.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 53
+    components:
+    - pos: -4.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 61
+    components:
+    - pos: -0.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 62
+    components:
+    - pos: -2.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 63
+    components:
+    - pos: -2.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 64
+    components:
+    - pos: -2.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 65
+    components:
+    - pos: -2.5,5.5
+      parent: 181
+      type: Transform
+  - uid: 66
+    components:
+    - pos: -1.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 82
+    components:
+    - pos: -0.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 83
+    components:
+    - pos: -4.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 84
+    components:
+    - pos: -3.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 132
+    components:
+    - pos: 0.5,2.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 144
+    components:
+    - pos: -5.5,1.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 165
+    components:
+    - pos: -0.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 168
+    components:
+    - pos: -3.5,-4.5
+      parent: 181
+      type: Transform
+- proto: CableHV
+  entities:
+  - uid: 6
+    components:
+    - pos: -3.5,-6.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 58
+    components:
+    - pos: -1.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 59
+    components:
+    - pos: -1.5,-6.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 74
+    components:
+    - pos: -3.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 75
+    components:
+    - pos: -2.5,-6.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 76
+    components:
+    - pos: -4.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: CableMV
+  entities:
+  - uid: 8
+    components:
+    - pos: -0.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 9
+    components:
+    - pos: -2.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 10
+    components:
+    - pos: -2.5,2.5
+      parent: 181
+      type: Transform
+  - uid: 11
+    components:
+    - pos: -2.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 12
+    components:
+    - pos: -2.5,-0.5
+      parent: 181
+      type: Transform
+  - uid: 16
+    components:
+    - pos: -2.5,-1.5
+      parent: 181
+      type: Transform
+  - uid: 17
+    components:
+    - pos: -2.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 18
+    components:
+    - pos: -4.5,3.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 19
+    components:
+    - pos: -2.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 20
+    components:
+    - pos: -3.5,3.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 31
+    components:
+    - pos: -2.5,1.5
+      parent: 181
+      type: Transform
+  - uid: 60
+    components:
+    - pos: -2.5,-4.5
+      parent: 181
+      type: Transform
+  - uid: 70
+    components:
+    - pos: -4.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 71
+    components:
+    - pos: -3.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 72
+    components:
+    - pos: -2.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+  - uid: 73
+    components:
+    - pos: -1.5,-5.5
+      parent: 181
+      type: Transform
+    - enabled: True
+      type: AmbientSound
+- proto: CableTerminal
+  entities:
+  - uid: 77
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,-6.5
+      parent: 181
+      type: Transform
+- proto: Catwalk
+  entities:
+  - uid: 48
+    components:
+    - pos: -2.5,-5.5
+      parent: 181
+      type: Transform
+- proto: Chair
+  entities:
+  - uid: 55
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -2.5,5.5
+      parent: 181
+      type: Transform
+- proto: ComputerRadar
+  entities:
+  - uid: 126
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,5.5
+      parent: 181
+      type: Transform
+- proto: ComputerShuttle
+  entities:
+  - uid: 121
+    components:
+    - pos: -2.5,6.5
+      parent: 181
+      type: Transform
+- proto: GasPort
+  entities:
+  - uid: 25
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-4.5
+      parent: 181
+      type: Transform
+- proto: GasVentPump
+  entities:
+  - uid: 26
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -3.5,-4.5
+      parent: 181
+      type: Transform
+    - enabled: False
+      type: AmbientSound
+- proto: GeneratorBasic
+  entities:
+  - uid: 40
+    components:
+    - pos: -1.5,-5.5
+      parent: 181
+      type: Transform
+- proto: GeneratorPlasma
+  entities:
+  - uid: 67
+    components:
+    - pos: -1.5,-6.5
+      parent: 181
+      type: Transform
+- proto: Girder
+  entities:
+  - uid: 2
+    components:
+    - pos: -3.5,0.5
+      parent: 181
+      type: Transform
+- proto: GravityGeneratorMini
+  entities:
+  - uid: 39
+    components:
+    - pos: -3.5,-6.5
+      parent: 181
+      type: Transform
+- proto: Grille
+  entities:
+  - uid: 33
+    components:
+    - pos: -2.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 50
+    components:
+    - pos: -1.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 56
+    components:
+    - pos: -3.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 57
+    components:
+    - pos: -0.5,5.5
+      parent: 181
+      type: Transform
+  - uid: 135
+    components:
+    - pos: -4.5,5.5
+      parent: 181
+      type: Transform
+  - uid: 136
+    components:
+    - pos: -2.5,7.5
+      parent: 181
+      type: Transform
+  - uid: 139
+    components:
+    - pos: -4.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 151
+    components:
+    - pos: -1.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 152
+    components:
+    - pos: -3.5,7.5
+      parent: 181
+      type: Transform
+  - uid: 155
+    components:
+    - pos: -0.5,6.5
+      parent: 181
+      type: Transform
+- proto: Gyroscope
+  entities:
+  - uid: 169
+    components:
+    - pos: -0.5,-0.5
+      parent: 181
+      type: Transform
+- proto: PaperOffice
+  entities:
+  - uid: 134
+    components:
+    - pos: -2.4897633,6.5107956
+      parent: 181
+      type: Transform
+    - stampState: paper_stamp-centcom
+      stampedBy:
+      - CentCom
+      content: >-
+        NanoTrasen Shipyard and Marine
+
+
+        Hey, whoever's reading this, I assume people already told you what's happening with the magnets right? We were going to scrap these old model shuttles, but we've been told to fulfil a requisition order for salvagers across several stations in multiple sectors. Basically, if you move the magnet onto the shuttle, and position it "front towards enemy" style with the coloured markings away from anything important, it should function as normal. Other than that, don't drink and fly and don't fuck anything up!
+
+
+        - Pym and pals
+      type: Paper
+- proto: PersonalAI
+  entities:
+  - uid: 167
+    components:
+    - flags: SessionSpecific
+      type: MetaData
+    - pos: -1.4453101,4.467156
+      parent: 181
+      type: Transform
+- proto: PoweredSmallLight
+  entities:
+  - uid: 138
+    components:
+    - pos: -5.5,2.5
+      parent: 181
+      type: Transform
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 140
+    components:
+    - rot: 3.141592653589793 rad
+      pos: 0.5,1.5
+      parent: 181
+      type: Transform
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 141
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -3.5,4.5
+      parent: 181
+      type: Transform
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 142
+    components:
+    - pos: -0.5,-0.5
+      parent: 181
+      type: Transform
+    - powerLoad: 0
+      type: ApcPowerReceiver
+  - uid: 143
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -4.5,-4.5
+      parent: 181
+      type: Transform
+    - powerLoad: 0
+      type: ApcPowerReceiver
+- proto: Rack
+  entities:
+  - uid: 27
+    components:
+    - pos: -1.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 52
+    components:
+    - pos: -0.5,-4.5
+      parent: 181
+      type: Transform
+- proto: RandomPosterAny
+  entities:
+  - uid: 13
+    components:
+    - pos: -4.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 22
+    components:
+    - pos: -0.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 23
+    components:
+    - pos: -4.5,-6.5
+      parent: 181
+      type: Transform
+- proto: RandomSpawner
+  entities:
+  - uid: 127
+    components:
+    - pos: -4.5,-0.5
+      parent: 181
+      type: Transform
+  - uid: 128
+    components:
+    - pos: -0.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 129
+    components:
+    - pos: -0.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 130
+    components:
+    - pos: -3.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 131
+    components:
+    - pos: -3.5,-5.5
+      parent: 181
+      type: Transform
+  - uid: 133
+    components:
+    - pos: -2.5,-2.5
+      parent: 181
+      type: Transform
+- proto: SalvageShuttleConsoleCircuitboard
+  entities:
+  - uid: 105
+    components:
+    - pos: -1.340611,5.409737
+      parent: 181
+      type: Transform
+- proto: SMESBasic
+  entities:
+  - uid: 24
+    components:
+    - pos: -2.5,-6.5
+      parent: 181
+      type: Transform
+- proto: SubstationWallBasic
+  entities:
+  - uid: 5
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -4.5,-5.5
+      parent: 181
+      type: Transform
+- proto: Table
+  entities:
+  - uid: 125
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: -1.5,5.5
+      parent: 181
+      type: Transform
+- proto: Thruster
+  entities:
+  - uid: 35
+    components:
+    - pos: 0.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 115
+    components:
+    - rot: -1.5707963267948966 rad
+      pos: 1.5,-0.5
+      parent: 181
+      type: Transform
+  - uid: 119
+    components:
+    - rot: 3.141592653589793 rad
+      pos: -5.5,-6.5
+      parent: 181
+      type: Transform
+  - uid: 120
+    components:
+    - rot: 1.5707963267948966 rad
+      pos: -6.5,-0.5
+      parent: 181
+      type: Transform
+- proto: WallSolid
+  entities:
+  - uid: 85
+    components:
+    - pos: -4.5,-6.5
+      parent: 181
+      type: Transform
+  - uid: 87
+    components:
+    - pos: -4.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 89
+    components:
+    - pos: 0.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 90
+    components:
+    - pos: -5.5,-5.5
+      parent: 181
+      type: Transform
+  - uid: 91
+    components:
+    - pos: 1.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 97
+    components:
+    - pos: -0.5,-5.5
+      parent: 181
+      type: Transform
+  - uid: 99
+    components:
+    - pos: 0.5,-4.5
+      parent: 181
+      type: Transform
+  - uid: 103
+    components:
+    - pos: -6.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 104
+    components:
+    - pos: -0.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 106
+    components:
+    - pos: 0.5,-5.5
+      parent: 181
+      type: Transform
+  - uid: 107
+    components:
+    - pos: -4.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 108
+    components:
+    - pos: -0.5,-6.5
+      parent: 181
+      type: Transform
+  - uid: 109
+    components:
+    - pos: -0.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 110
+    components:
+    - pos: -5.5,-4.5
+      parent: 181
+      type: Transform
+  - uid: 111
+    components:
+    - pos: -5.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 112
+    components:
+    - pos: -4.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 114
+    components:
+    - pos: -5.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 116
+    components:
+    - pos: -4.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 117
+    components:
+    - pos: 0.5,3.5
+      parent: 181
+      type: Transform
+  - uid: 118
+    components:
+    - pos: -5.5,-0.5
+      parent: 181
+      type: Transform
+  - uid: 122
+    components:
+    - pos: 0.5,-0.5
+      parent: 181
+      type: Transform
+  - uid: 123
+    components:
+    - pos: 1.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 124
+    components:
+    - pos: -6.5,0.5
+      parent: 181
+      type: Transform
+- proto: WallSolidRust
+  entities:
+  - uid: 113
+    components:
+    - pos: -0.5,0.5
+      parent: 181
+      type: Transform
+  - uid: 145
+    components:
+    - pos: -0.5,4.5
+      parent: 181
+      type: Transform
+  - uid: 147
+    components:
+    - pos: -4.5,-5.5
+      parent: 181
+      type: Transform
+- proto: Window
+  entities:
+  - uid: 37
+    components:
+    - pos: 0.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 46
+    components:
+    - pos: -5.5,-1.5
+      parent: 181
+      type: Transform
+  - uid: 47
+    components:
+    - pos: 0.5,-1.5
+      parent: 181
+      type: Transform
+  - uid: 69
+    components:
+    - pos: 0.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 78
+    components:
+    - pos: -2.5,7.5
+      parent: 181
+      type: Transform
+  - uid: 79
+    components:
+    - pos: -1.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 80
+    components:
+    - pos: -3.5,7.5
+      parent: 181
+      type: Transform
+  - uid: 81
+    components:
+    - pos: -3.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 86
+    components:
+    - pos: -1.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 88
+    components:
+    - pos: -0.5,5.5
+      parent: 181
+      type: Transform
+  - uid: 92
+    components:
+    - pos: -1.5,7.5
+      parent: 181
+      type: Transform
+  - uid: 93
+    components:
+    - pos: -0.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 94
+    components:
+    - pos: -5.5,-3.5
+      parent: 181
+      type: Transform
+  - uid: 95
+    components:
+    - pos: -5.5,-2.5
+      parent: 181
+      type: Transform
+  - uid: 96
+    components:
+    - pos: -3.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 98
+    components:
+    - pos: -2.5,-7.5
+      parent: 181
+      type: Transform
+  - uid: 101
+    components:
+    - pos: -4.5,6.5
+      parent: 181
+      type: Transform
+  - uid: 102
+    components:
+    - pos: -4.5,5.5
+      parent: 181
+      type: Transform
+...

--- a/Resources/Prototypes/Entities/Stations/base.yml
+++ b/Resources/Prototypes/Entities/Stations/base.yml
@@ -35,11 +35,11 @@
 - type: entity
   id: BaseStationShuttles
   abstract: true
-#  components:
-#   - type: GridSpawn
-#     paths:
+  components:
+   - type: GridSpawn
+     paths:
 #       - /Maps/Shuttles/cargo.yml
-#       - /Maps/Shuttles/mining.yml # Note, this doesn't spawn on a seperate map, salvage doesnt deserve it :)
+       - /Maps/Shuttles/mining-deltav.yml
 
 - type: entity
   id: BaseStationCentcomm


### PR DESCRIPTION
## About the PR
Truly the shittle of all time.

Gives salvage something that lets the magnet work, and also something to do with the materials they collect. This is only really a trial to see if they'll behave with it or not


**Media**
![image](https://github.com/DeltaV-Station/Delta-v/assets/49997488/cb8ec7ab-eda6-469a-854c-cc73dd59012d)

**Changelog**

:cl:
- add: NanoTrasen Shipyards has fulfilled an order for several decommissioned reclaimer class shuttles, you may find one on a station near you.
