### PR TITLE
Prevent multiple automatic changelog updates at once

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,4 +1,5 @@
 name: PR Changelogs
+concurrency: commit_action
 on:
   pull_request_target:
     types: [closed]


### PR DESCRIPTION
## About the PR
Prevent multiple automatic changelog updates from running at once, as any started after another one is running will result in the action failing due to trying to modify the same file.