### PR TITLE
mail teleporter time on examine

### DIFF
--- a/Content.Server/Nyanotrasen/Mail/MailSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailSystem.cs
@@ -21,7 +21,6 @@ using Content.Server.Mail.Components;
 using Content.Server.Mind;
 using Content.Server.Nutrition.Components;
 using Content.Server.Popups;
-using Content.Server.Power.Components;
 using Content.Server.Station.Systems;
 using Content.Server.Spawners.EntitySystems;
 using Content.Shared.Access.Components;
@@ -83,25 +82,6 @@ namespace Content.Server.Mail
             SubscribeLocalEvent<MailComponent, DamageChangedEvent>(OnDamage);
             SubscribeLocalEvent<MailComponent, BreakageEventArgs>(OnBreak);
             SubscribeLocalEvent<MailComponent, GotEmaggedEvent>(OnMailEmagged);
-        }
-
-        public override void Update(float frameTime)
-        {
-            base.Update(frameTime);
-            foreach (var mailTeleporter in EntityQuery<MailTeleporterComponent>())
-            {
-                if (TryComp<ApcPowerReceiverComponent>(mailTeleporter.Owner, out var power) && !power.Powered)
-                    return;
-
-                mailTeleporter.Accumulator += frameTime;
-
-                if (mailTeleporter.Accumulator < mailTeleporter.TeleportInterval.TotalSeconds)
-                    continue;
-
-                mailTeleporter.Accumulator -= (float) mailTeleporter.TeleportInterval.TotalSeconds;
-
-                SpawnMail(mailTeleporter.Owner, mailTeleporter);
-            }
         }
 
         /// <summary>

--- a/Content.Server/Nyanotrasen/Mail/MailTeleporterSystem.cs
+++ b/Content.Server/Nyanotrasen/Mail/MailTeleporterSystem.cs
@@ -1,0 +1,50 @@
+using Content.Server.Mail.Components;
+using Content.Server.Power.Components;
+using Content.Shared.Examine;
+
+namespace Content.Server.Mail;
+
+/// <summary>
+/// Handles spawning mail and showing time before next mail batch when examined.
+/// </summary>
+public sealed class MailTeleporterSystem : EntitySystem
+{
+    [Dependency] private readonly MailSystem _mail = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        SubscribeLocalEvent<MailTeleporterComponent, ExaminedEvent>(OnExamined);
+    }
+
+    private void OnExamined(EntityUid uid, MailTeleporterComponent comp, ExaminedEvent args)
+    {
+        if (!args.IsInDetailsRange)
+            return;
+
+        var time = Math.Ceiling(comp.TeleportInterval.TotalSeconds - comp.Accumulator);
+        args.PushMarkup(Loc.GetString("mail-teleporter-desc", ("timeLeft", time)));
+    }
+
+    public override void Update(float frameTime)
+    {
+        base.Update(frameTime);
+
+        var query = EntityQueryEnumerator<MailTeleporterComponent>();
+        while (query.MoveNext(out var uid, out var comp))
+        {
+            if (TryComp<ApcPowerReceiverComponent>(uid, out var power) && !power.Powered)
+                return;
+
+            comp.Accumulator += frameTime;
+
+            if (comp.Accumulator < comp.TeleportInterval.TotalSeconds)
+                continue;
+
+            comp.Accumulator -= (float) comp.TeleportInterval.TotalSeconds;
+
+            _mail.SpawnMail(uid, comp);
+        }
+    }
+}

--- a/Resources/Locale/en-US/Mail/mail.ftl
+++ b/Resources/Locale/en-US/Mail/mail.ftl
@@ -15,6 +15,11 @@ mail-penalty-expired = DELIVERY PAST DUE. CARGO BANK ACCOUNT PENALIZED BY {$cred
 mail-item-name-unaddressed = mail
 mail-item-name-addressed = mail ({$recipient})
 
+mail-teleporter-desc = The next batch of mail will be teleported in {$timeLeft ->
+    [1] one second.
+    *[other] {$timeLeft} seconds.
+}
+
 command-mailto-description = Queue a parcel to be delivered to an entity. Example usage: `mailto 1234 5678 false false`. The target container's contents will be transferred to an actual mail parcel.
 command-mailto-help = Usage: {$command} <recipient entityUid> <container entityUid> [is-fragile: true or false] [is-priority: true or false]
 command-mailto-no-mailreceiver = Target recipient entity does not have a {$requiredComponent}.


### PR DESCRIPTION
## About the PR
- show seconds until next teleport when examined
- also moved update into its own system since its not related to mail handling
  ideally would move all the teleporter related stuff but theres a lot and it would probably break tests

**Media**
![22:58:53](https://github.com/DeltaV-Station/Delta-v/assets/39013340/8a50be15-bc61-4ae9-9847-053f10952e82)

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Mail teleporters now show time until next teleport when examined.