### PR TITLE
Fix issues with adjutant and vulcan

### DIFF
--- a/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
+++ b/Resources/Locale/en-US/prototypes/catalog/fills/crates/armory-crates.ftl
@@ -7,17 +7,17 @@ ent-CrateArmoryShotgun = Shotgun crate
 ent-CrateTrackingImplants = Tracking implants
     .desc = Contains a handful of tracking implanters. Good for prisoners you'd like to release but still keep track of.
 
-ent-CrateArmoryLaser = lasers crate
+ent-CrateArmoryLaser = Lasers crate
     .desc = Contains three lethal, high-energy laser guns. Requires Armory access to open.
 
-ent-CrateArmoryPistols = pistols crate
+ent-CrateArmoryPistols = Pistols crate
     .desc = Contains two standard NT pistols with four mags. Requires Armory access to open.
 
-ent-CrateArmoryGrand = rifles crate
+ent-CrateArmoryGrand = Rifles crate
     .desc = Contains two Mark 1 Rifles and a box of speed-loaders. Requires Armory access to open.
 
 ent-CrateArmoryUniversal = Universal crate
     .desc = Contains two Mk32 Universal handguns with four mags. Requires Armory access to open.
 
 ent-CrateArmoryAdjutant = Adjutant crate
-    .desc = Contains two Adjutant shotguns with 4 ammo drums. Requires Armory access to open.
+    .desc = Contains two Adjutant shotguns with 3 ammo boxes. Requires Armory access to open.

--- a/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/armory.yml
@@ -48,14 +48,3 @@
       amount: 2
     - id: MagazinePistol
       amount: 4
-
-- type: entity
-  id: CrateArmoryShotgunAdjutant
-  parent: CrateWeaponSecure
-  components:
-  - type: StorageFill
-    contents:
-    - id: WeaponShotgunAdjutant
-      amount: 2
-    - id: BoxLethalshot
-      amount: 3

--- a/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Cargo/cargo_armory.yml
@@ -23,7 +23,7 @@
   icon:
     sprite: DeltaV/Objects/Weapons/Guns/Shotguns/Adjutant.rsi
     state: icon
-  product: WeaponShotgunAdjutant
+  product: CrateArmoryAdjutant
   cost: 9000
   category: Armory
   group: market

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Crates/armory.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Crates/armory.yml
@@ -19,3 +19,14 @@
         amount: 2
       - id: MagazineUniversalCaselessRifle
         amount: 4
+
+- type: entity
+  id: CrateArmoryAdjutant
+  parent: CrateWeaponSecure
+  components:
+  - type: StorageFill
+    contents:
+    - id: WeaponShotgunAdjutant
+      amount: 2
+    - id: BoxLethalshot
+      amount: 3

--- a/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
+++ b/Resources/Prototypes/DeltaV/Catalog/Fills/Lockers/security.yml
@@ -25,11 +25,11 @@
 - type: entity
   parent: GunSafe
   id: GunSafeVulcanRifle
-  name: Vulcan safe
+  name: vulcan safe
   components:
   - type: StorageFill
     contents:
-    - id: WeaponVulcanRifle
+    - id: WeaponRifleVulcan
       amount: 2
     - id: MagazineLightRifle
       amount: 4
@@ -37,7 +37,7 @@
 - type: entity
   parent: GunSafe
   id: GunSafeAdjutantShotgun
-  name: Adjutant safe
+  name: adjutant safe
   components:
   - type: StorageFill
     contents:

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: Vulcan
+  name: vulcan
   parent: BaseWeaponRifle
-  id: WeaponVulcanRifle
-  description: One of the first firearms modified for space usage, used to punch holes in cargonia "combat mechs"
+  id: WeaponRifleVulcan
+  description: One of the first firearms modified for space usage, this rifle has been used to punch holes in Cargonian "combat mechs."
   components:
   - type: Sprite
     sprite: DeltaV/Objects/Weapons/Guns/Rifles/vulcan.rsi

--- a/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
+++ b/Resources/Prototypes/DeltaV/Entities/Objects/Weapons/Guns/Shotguns/shotguns.yml
@@ -1,8 +1,8 @@
 - type: entity
-  name: Adjutant
+  name: adjutant
   parent: BaseWeaponShotgun
   id: WeaponShotgunAdjutant
-  description: sold as a "riot" shotgun, this shotgun has a special gas-operated mechanism that makes it highly effective for CQC and suppressive fire
+  description: Sold as a "riot" shotgun, this shotgun has a special gas-operated mechanism that makes it highly effective for CQC and suppressive fire.
   components:
   - type: Sprite
     sprite: DeltaV/Objects/Weapons/Guns/Shotguns/Adjutant.rsi


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Fixes a series of issues with these two weapons.
* Changed prototypes to fit conventions (WeaponVulcanRifle into WeaponRifleVulcan, CrateArmoryShotgunAdjutant into CrateArmoryAdjutant)
* Corrected item capitalization and corrected grammar in item descriptions
* Made sure cargo receives a crate and not just an adjutant shotgun

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- fix: Fixed bug where ordering a crate of adjutant shotguns gives cargo a shotgun and no crate.
