### PR TITLE
Paramedic Locker Locked

### DIFF
--- a/Resources/Prototypes/Access/medical.yml
+++ b/Resources/Prototypes/Access/medical.yml
@@ -9,7 +9,7 @@
 - type: accessLevel
   id: Chemistry
   name: id-card-access-level-chemistry
-  
+
 - type: accessLevel
   id: Paramedic
   name: id-card-access-level-paramedic
@@ -20,3 +20,4 @@
   - ChiefMedicalOfficer
   - Medical
   - Chemistry
+  - Paramedic

--- a/Resources/Prototypes/Access/misc.yml
+++ b/Resources/Prototypes/Access/misc.yml
@@ -15,6 +15,7 @@
   - Brig
   - Engineering
   - Medical
+  - Paramedic
   - Mail
   - Salvage
   - Cargo

--- a/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
+++ b/Resources/Prototypes/Entities/Structures/Storage/Closets/Lockers/lockers.yml
@@ -225,7 +225,7 @@
     stateDoorOpen: paramed_open
     stateDoorClosed: paramed_door
   - type: AccessReader
-    access: [ [ "Medical" ] ]
+    access: [ [ "Paramedic" ] ]
 
 
 # Chemical

--- a/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/chief_medical_officer.yml
@@ -20,6 +20,7 @@
   supervisors: job-supervisors-captain
   access:
   - Medical
+  - Paramedic
   - Command
   - Maintenance
   - Chemistry

--- a/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
+++ b/Resources/Prototypes/Roles/Jobs/Medical/paramedic.yml
@@ -12,6 +12,7 @@
   supervisors: job-supervisors-cmo
   access:
   - Medical
+  - Paramedic
   - Maintenance
   - Service
   - External


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->

Fixes the biggest annoyance playing Paramedic: any doctor being able to open your locker and nab your HUD and suit. Tested and works.

Accessreaders apparently did not even have an entry for Paramedics, so that was added. The **PARAMEDIC SECURE WINDOOR**™℠®© will now function properly!

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- tweak: Paramedic lockers are now only unlockable by Paramedics and CMOs.