### PR TITLE
cap mass media articles

### DIFF
--- a/Content.Client/MassMedia/Ui/NewsWriteBoundUserInterface.cs
+++ b/Content.Client/MassMedia/Ui/NewsWriteBoundUserInterface.cs
@@ -74,7 +74,7 @@ namespace Content.Client.MassMedia.Ui
             var stringName = _menu.NameInput.Text;
             var name = (stringName.Length <= 25 ? stringName.Trim() : $"{stringName.Trim().Substring(0, 25)}...");
             article.Name = name;
-            article.Content = stringContent;
+            article.Content = stringContent.Substring(0, Math.Min(stringContent.Length, 32768));
             article.ShareTime = _gameTiming.CurTime.Subtract(_gameTicker.RoundStartTimeSpan);
 
             _menu.ContentInput.TextRope = new Rope.Leaf(string.Empty);


### PR DESCRIPTION
no more 500px wide images, no more network lag

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
This PR caps the maximum news article size to 32KB, dampening network lag severely.
Client lag is also nonexistent now - previously occured at about 500KB on my relatively low end graphics card (Radeon HD 6850).

**Media**
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/74166a23-7f33-485b-ba9f-9b3eb5f10429)
after applying a clientside cap
![image](https://github.com/DeltaV-Station/Delta-v/assets/21104932/d44c8646-fb6a-4a64-8be6-49f9c944df44)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
no cl no fun