### PR TITLE
make stimpacks pierce armour

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/hypospray.yml
@@ -188,6 +188,7 @@
   - type: Hypospray
     solutionName: pen
     transferAmount: 30
+    pierceArmor: true
   - type: DynamicPrice
     price: 500
   - type: Tag
@@ -214,6 +215,8 @@
         reagents:
         - ReagentId: Stimulants
           Quantity: 15
+  - type: Hypospray
+    pierceArmor: true
   - type: DynamicPrice
     price: 100
   - type: Tag


### PR DESCRIPTION
## About the PR
so nukies can use stims

**Media**
- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
:cl:
- tweak: Stimulant injectors now pierce armor.