### PR TITLE
Early Merge - Fix warden wintercoat

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/wintercoats.yml
@@ -77,7 +77,7 @@
     sprite: Clothing/OuterClothing/WinterCoats/coatcentcom.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/WinterCoats/coatcentcom.rsi
-    
+
 - type: entity
   parent: ClothingOuterWinterCoat
   id: ClothingOuterWinterChef
@@ -360,6 +360,7 @@
   - type: Sprite
     sprite: Clothing/OuterClothing/WinterCoats/coatwarden.rsi
   - type: Clothing
+    sprite: Clothing/OuterClothing/WinterCoats/coatwarden.rsi
   - type: Armor
     modifiers:
       coefficients:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
https://github.com/Nyanotrasen/Nyanotrasen/pull/1790

## About the PR
<!-- What does it change? What other things could this impact? -->
Fixes the Warden Winter coat using the default winter coat sprite instead of it's actual sprite.
It was just one line that got removed.

**Changelog**
no
