### PR TITLE
Buff and Tweak Eswords

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/e_sword.yml
@@ -7,8 +7,7 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 15
-            Heat: 15
+            Heat: 30             #Originally was 15 heat and 15 slash
             Structural: 4
             Blunt: -4.5
     litDisarmMalus: 0.6
@@ -53,6 +52,9 @@
     malus: 0
   - type: Reflect
     enabled: false
+    reflectProb: 0.50
+    reflects:
+        - Energy
 
 - type: entity
   name: pen
@@ -65,8 +67,7 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 9
-            Heat: 9
+            Heat: 18      #Originally was 9 heat 9 slash
             Blunt: -1
     litDisarmMalus: 0.4
   - type: Sprite
@@ -137,8 +138,7 @@
     secret: true
     litDamageBonus:
         types:
-            Slash: 7.5
-            Heat: 7.5
+            Heat: 15         #Originally was 7.5 slash 7.5 heat
             Blunt: -1
     litDisarmMalus: 0.6
   - type: Sprite
@@ -165,16 +165,15 @@
   - type: EnergySword
     litDamageBonus:
         types:
-            Slash: 9
-            Heat: 9
-            Structural: 20
+            Heat: 34  #Originally was 9 heat 9 slash
+           #Structural: 20
             Blunt: -4.5
     litDisarmMalus: 0.7
   - type: MeleeWeapon
     attackRate: 1.6
     angle: 100
     # heavyWindupModifier: .9
-    heavyDamageModifier: 1.5
+    # heavyDamageModifier: 1.5
     soundHit:
       path: /Audio/Weapons/eblade1.ogg
     damage:
@@ -194,5 +193,7 @@
     sprite: Objects/Weapons/Melee/e_sword_double.rsi
   - type: Reflect
     enabled: true
-    reflectProb: .75
+    reflectProb: 1
     spread: 75
+    reflects: 
+        - Energy


### PR DESCRIPTION
Tweaks the eswords to deal heat damage instead of half heat and half slash Tweaks eswords to have only energy weapon reflection Buffs Deswords by making it have 100% energy projectile reflection Buffs Desword to deal 34 heat damage with no structural

<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What does it change? What other things could this impact? -->
This PR makes energy swords actually deal heat damage and buffs the double bladed energy sword. This could make more people want to actually spent a whole 16 TC on a double bladed energy sword. Energy swords also only reflect energy projectiles

**Media**
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase

**Changelog**
<!--
Here you can fill out a changelog that will automatically be added to the game when your PR is merged.

Only put changes that are visible and important to the player on the changelog.

Don't consider the entry type suffix (e.g. add) to be "part" of the sentence:
bad: - add: a new tool for engineers
good: - add: added a new tool for engineers

Putting a name after the :cl: symbol will change the name that shows in the changelog (otherwise it takes your GitHub username)
Like so: :cl: PJB
-->

:cl:
- remove: Removed the ability for all energy swords to reflect ballistic projectiles.
- tweak: Changed the damage of the Energy Sword to 30 heat and the Double bladed energy Sword from 9 heat and 9 slash to 34 heat. Increased the reflection chance of the Double Bladed Energy sword from 75% to 100%

